### PR TITLE
feat: add native binary compilation support to builder

### DIFF
--- a/.changeset/feat-native-build-support.md
+++ b/.changeset/feat-native-build-support.md
@@ -1,0 +1,6 @@
+---
+"@djs-core/dev": minor
+---
+
+feat: add support for native binary compilation using `bun build --compile`. 
+Includes a new `--compile` (or `-c`) flag and an interactive menu option with a size warning.

--- a/.changeset/fix-build-command-hang.md
+++ b/.changeset/fix-build-command-hang.md
@@ -1,0 +1,5 @@
+---
+"@djs-core/dev": patch
+---
+
+fix: ensure build command exits cleanly after completion by forcing process exit.

--- a/packages/dev/commands/build.ts
+++ b/packages/dev/commands/build.ts
@@ -410,7 +410,9 @@ export function registerBuildCommand(cli: CAC) {
 						`  Build success: ${pc.bold(exeName)} (${sizeMB} MB)`,
 				);
 				console.log(pc.dim(`  - ${outputPath}`));
-				console.log(pc.dim(`\nTip: run your bot with: ./${options.outdir}/${exeName}\n`));
+				console.log(
+					pc.dim(`\nTip: run your bot with: ./${options.outdir}/${exeName}\n`),
+				);
 				process.exit(0);
 			}
 

--- a/packages/dev/commands/build.ts
+++ b/packages/dev/commands/build.ts
@@ -411,7 +411,7 @@ export function registerBuildCommand(cli: CAC) {
 				);
 				console.log(pc.dim(`  - ${outputPath}`));
 				console.log(pc.dim(`\nTip: run your bot with: ./${options.outdir}/${exeName}\n`));
-				return;
+				process.exit(0);
 			}
 
 			const botPackageJsonPath = path.join(botRoot, "package.json");
@@ -536,5 +536,7 @@ CMD ["bun", "index.js"]
 					),
 				);
 			}
+
+			process.exit(0);
 		});
 }

--- a/packages/dev/commands/build.ts
+++ b/packages/dev/commands/build.ts
@@ -13,6 +13,7 @@ type BuildOptions = {
 	path: string;
 	outdir: string;
 	minify: boolean;
+	compile: boolean;
 };
 
 function toPosixPath(p: string): string {
@@ -277,6 +278,7 @@ export function registerBuildCommand(cli: CAC) {
 			{ default: "dist" },
 		)
 		.option("--no-minify", "Disable minification")
+		.option("-c, --compile", "Compile to a standalone binary")
 		.action(async (options: BuildOptions) => {
 			console.log(banner);
 
@@ -341,14 +343,19 @@ export function registerBuildCommand(cli: CAC) {
 
 			await fs.writeFile(entryPath, code, "utf8");
 
-			const buildType = await select({
-				message: "Select build type:",
-				options: [
-					{ value: "bun", label: "Bun (bundled)" },
-					{ value: "bun-external", label: "Bun (external deps)" },
-					{ value: "docker", label: "Docker" },
-				],
-			});
+			let buildType = options.compile ? "compile" : null;
+
+			if (!buildType) {
+				buildType = (await select({
+					message: "Select build type:",
+					options: [
+						{ value: "bun", label: "Bun (bundled)" },
+						{ value: "bun-external", label: "Bun (external deps)" },
+						{ value: "compile", label: "Compile (Native binary, ~90MB)" },
+						{ value: "docker", label: "Docker" },
+					],
+				})) as string;
+			}
 
 			if (typeof buildType !== "string") {
 				console.log(pc.red("❌ Build cancelled"));
@@ -364,6 +371,48 @@ export function registerBuildCommand(cli: CAC) {
 			}
 
 			await fs.mkdir(outdirAbs, { recursive: true });
+
+			if (buildType === "compile") {
+				const exeName = process.platform === "win32" ? "bot.exe" : "bot";
+				const outputPath = path.join(outdirAbs, exeName);
+
+				console.log(`${pc.cyan("ℹ")}  Compiling native binary...`);
+
+				const buildArgs = [
+					"build",
+					entryPath,
+					"--compile",
+					"--outfile",
+					outputPath,
+				];
+
+				if (options.minify !== false) {
+					buildArgs.push("--minify");
+				}
+
+				const proc = Bun.spawn(["bun", ...buildArgs], {
+					stdout: "inherit",
+					stderr: "inherit",
+				});
+
+				const exitCode = await proc.exited;
+
+				if (exitCode !== 0) {
+					console.error(pc.red("\n❌ Compilation failed"));
+					process.exit(1);
+				}
+
+				const stats = await fs.stat(outputPath);
+				const sizeMB = (stats.size / (1024 * 1024)).toFixed(2);
+
+				console.log(
+					pc.green("\n✓") +
+						`  Build success: ${pc.bold(exeName)} (${sizeMB} MB)`,
+				);
+				console.log(pc.dim(`  - ${outputPath}`));
+				console.log(pc.dim(`\nTip: run your bot with: ./${options.outdir}/${exeName}\n`));
+				return;
+			}
 
 			const botPackageJsonPath = path.join(botRoot, "package.json");
 			let externalDeps: string[] = [];


### PR DESCRIPTION
This pull request adds support for compiling native binaries using Bun, introduces a new `--compile` flag and an interactive menu option, and ensures the build command exits cleanly after completion. The changes enhance the build process by allowing users to produce standalone executables and improve reliability by addressing potential hangs.

**Native binary compilation support:**

* Added a `--compile` (or `-c`) flag to the build command and an interactive menu option for compiling to a standalone native binary using `bun build --compile`, including a size warning in the prompt. (`packages/dev/commands/build.ts`, `.changeset/feat-native-build-support.md`, [[1]](diffhunk://#diff-fb25ffbb06c8199ee8cd441ce7adcb1464f05c335b31e1a1df6ab863502bd473R1-R6) [[2]](diffhunk://#diff-f3c3e3907cadfe874e08198177da69aa258f9f6559e4fc3e5201db47b8167985R16) [[3]](diffhunk://#diff-f3c3e3907cadfe874e08198177da69aa258f9f6559e4fc3e5201db47b8167985R281) [[4]](diffhunk://#diff-f3c3e3907cadfe874e08198177da69aa258f9f6559e4fc3e5201db47b8167985L344-R358)
* Implemented logic to handle the native compilation process, including output file naming, progress messages, error handling, and post-build instructions. (`packages/dev/commands/build.ts`, [packages/dev/commands/build.tsR375-R416](diffhunk://#diff-f3c3e3907cadfe874e08198177da69aa258f9f6559e4fc3e5201db47b8167985R375-R416))

**Build process reliability:**

* Ensured that the build command exits cleanly after completion by forcing a process exit, preventing potential hangs. (`packages/dev/commands/build.ts`, `.changeset/fix-build-command-hang.md`, [[1]](diffhunk://#diff-84258ec5e892e1050d91d5a2727ec93e2b55f1d8e75cc3ec88dc4338aa3fb5cfR1-R5) [[2]](diffhunk://#diff-f3c3e3907cadfe874e08198177da69aa258f9f6559e4fc3e5201db47b8167985R539-R540)