### PR TITLE
⚡ optimize ApplicationCommandHandler.sync to run concurrently

### DIFF
--- a/.changeset/optimize-app-command-registration.md
+++ b/.changeset/optimize-app-command-registration.md
@@ -1,0 +1,5 @@
+---
+"@djs-core/runtime": patch
+---
+
+Optimize application command registration by implementing parallel guild synchronization (via Promise.all) to improve performance and adding unit tests for command synchronization.

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "djs-core",
@@ -9,8 +8,8 @@
         "@changesets/cli": "^2.30.0",
         "dts-bundle-generator": "^9.5.1",
         "knip": "^5.86.0",
-        "typescript": "latest",
         "turbo": "^2.8.16",
+        "typescript": "latest",
       },
     },
     "app": {
@@ -26,7 +25,6 @@
       "devDependencies": {
         "@djs-core/dev": "workspace:*",
         "@types/bun": "latest",
-        "typescript": "latest",
       },
     },
     "packages/dev": {
@@ -72,7 +70,6 @@
       },
       "devDependencies": {
         "@types/bun": "latest",
-        "typescript": "^5",
       },
       "peerDependencies": {
         "discord.js": "^14.25.1",

--- a/packages/runtime/handler/ApplicationCommandHandler.ts
+++ b/packages/runtime/handler/ApplicationCommandHandler.ts
@@ -65,16 +65,16 @@ export default class ApplicationCommandHandler {
 			...this.contextMenus,
 		];
 
+		const application = this.client.application;
+		if (!application) {
+			throw new Error("Client application is not available");
+		}
+
 		if (this.guilds.length > 0) {
 			await Promise.all(
 				this.guilds.map(async (guildId) => {
 					try {
-						// We already checked this.client.application above, but TS loses context inside map
-						// biome-ignore lint/style/noNonNullAssertion: safe here since application is checked above
-						const created = await this.client.application!.commands.set(
-							allCommands,
-							guildId,
-						);
+						const created = await application.commands.set(allCommands, guildId);
 						this.refreshCacheFromSetResult(created, guildId);
 					} catch (error: unknown) {
 						if (
@@ -91,7 +91,7 @@ export default class ApplicationCommandHandler {
 			);
 		} else {
 			try {
-				const created = await this.client.application.commands.set(allCommands);
+				const created = await application.commands.set(allCommands);
 				this.refreshCacheFromSetResult(created, "global");
 			} catch (error: unknown) {
 				if (

--- a/packages/runtime/handler/ApplicationCommandHandler.ts
+++ b/packages/runtime/handler/ApplicationCommandHandler.ts
@@ -66,25 +66,27 @@ export default class ApplicationCommandHandler {
 		];
 
 		if (this.guilds.length > 0) {
-			for (const guildId of this.guilds) {
-				try {
-					const created = await this.client.application.commands.set(
-						allCommands,
-						guildId,
-					);
-					this.refreshCacheFromSetResult(created, guildId);
-				} catch (error: unknown) {
-					if (
-						error &&
-						typeof error === "object" &&
-						"code" in error &&
-						error.code === 10063
-					) {
-						continue;
+			await Promise.all(
+				this.guilds.map(async (guildId) => {
+					try {
+						const created = await this.client.application.commands.set(
+							allCommands,
+							guildId,
+						);
+						this.refreshCacheFromSetResult(created, guildId);
+					} catch (error: unknown) {
+						if (
+							error &&
+							typeof error === "object" &&
+							"code" in error &&
+							error.code === 10063
+						) {
+							return;
+						}
+						throw error;
 					}
-					throw error;
-				}
-			}
+				}),
+			);
 		} else {
 			try {
 				const created = await this.client.application.commands.set(allCommands);

--- a/packages/runtime/handler/ApplicationCommandHandler.ts
+++ b/packages/runtime/handler/ApplicationCommandHandler.ts
@@ -69,7 +69,9 @@ export default class ApplicationCommandHandler {
 			await Promise.all(
 				this.guilds.map(async (guildId) => {
 					try {
-						const created = await this.client.application.commands.set(
+						// We already checked this.client.application above, but TS loses context inside map
+						// biome-ignore lint/style/noNonNullAssertion: safe here since application is checked above
+						const created = await this.client.application!.commands.set(
 							allCommands,
 							guildId,
 						);

--- a/packages/runtime/handler/ApplicationCommandHandler.ts
+++ b/packages/runtime/handler/ApplicationCommandHandler.ts
@@ -74,7 +74,10 @@ export default class ApplicationCommandHandler {
 			await Promise.all(
 				this.guilds.map(async (guildId) => {
 					try {
-						const created = await application.commands.set(allCommands, guildId);
+						const created = await application.commands.set(
+							allCommands,
+							guildId,
+						);
 						this.refreshCacheFromSetResult(created, guildId);
 					} catch (error: unknown) {
 						if (

--- a/packages/runtime/test/application-command-handler.test.ts
+++ b/packages/runtime/test/application-command-handler.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, test, mock, beforeAll, afterAll } from "bun:test";
+import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test";
 import { Collection } from "discord.js";
 import ApplicationCommandHandler from "../handler/ApplicationCommandHandler";
 

--- a/packages/runtime/test/application-command-handler.test.ts
+++ b/packages/runtime/test/application-command-handler.test.ts
@@ -1,31 +1,70 @@
-import { describe, expect, test } from "bun:test";
+import { describe, expect, test, mock, beforeAll, afterAll } from "bun:test";
 import { Collection } from "discord.js";
 import ApplicationCommandHandler from "../handler/ApplicationCommandHandler";
 
-test("ApplicationCommandHandler benchmark", async () => {
-    const mockSet = async (commands: any, guildId?: string) => {
-        // simulate network delay
-        await new Promise((resolve) => setTimeout(resolve, 50));
-        return new Collection();
-    };
+describe("ApplicationCommandHandler", () => {
+    let originalSkipSync: string | undefined;
 
-    const client = {
-        isReady: () => true,
-        getDjsConfig: () => ({}),
-        application: {
-            commands: {
-                set: mockSet
+    beforeAll(() => {
+        originalSkipSync = process.env.SKIP_SYNC;
+        delete process.env.SKIP_SYNC;
+    });
+
+    afterAll(() => {
+        process.env.SKIP_SYNC = originalSkipSync;
+    });
+
+    test("sync calls commands.set for each guild in parallel", async () => {
+        const mockSet = mock(async (commands: any, guildId?: string) => {
+            return new Collection();
+        });
+
+        const client = {
+            isReady: () => true,
+            getDjsConfig: () => ({}),
+            application: {
+                commands: {
+                    set: mockSet
+                }
             }
+        } as any;
+
+        const handler = new ApplicationCommandHandler(client);
+        const guilds = Array.from({ length: 12 }, (_, i) => `guild-${i}`);
+        handler.setGuilds(guilds);
+
+        await handler.sync();
+
+        // Should be called 12 times
+        expect(mockSet).toHaveBeenCalledTimes(12);
+        
+        // Verify calls with correct guild IDs
+        for (let i = 0; i < guilds.length; i++) {
+            expect(mockSet).toHaveBeenNthCalledWith(i + 1, expect.any(Array), guilds[i]);
         }
-    } as any;
+    });
 
-    const handler = new ApplicationCommandHandler(client);
-    const guilds = Array.from({ length: 20 }, (_, i) => `guild-${i}`);
-    handler.setGuilds(guilds);
+    test("sync handles global registration when no guilds are specified", async () => {
+        const mockSet = mock(async (commands: any, guildId?: string) => {
+            return new Collection();
+        });
 
-    const start = performance.now();
-    await handler.sync();
-    const end = performance.now();
+        const client = {
+            isReady: () => true,
+            getDjsConfig: () => ({}),
+            application: {
+                commands: {
+                    set: mockSet
+                }
+            }
+        } as any;
 
-    console.log(`Sync time for ${guilds.length} guilds: ${end - start}ms`);
+        const handler = new ApplicationCommandHandler(client);
+        handler.setGuilds([]);
+
+        await handler.sync();
+
+        expect(mockSet).toHaveBeenCalledTimes(1);
+        expect(mockSet).toHaveBeenCalledWith(expect.any(Array));
+    });
 });

--- a/packages/runtime/test/application-command-handler.test.ts
+++ b/packages/runtime/test/application-command-handler.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+import { Collection } from "discord.js";
+import ApplicationCommandHandler from "../handler/ApplicationCommandHandler";
+
+test("ApplicationCommandHandler benchmark", async () => {
+    const mockSet = async (commands: any, guildId?: string) => {
+        // simulate network delay
+        await new Promise((resolve) => setTimeout(resolve, 50));
+        return new Collection();
+    };
+
+    const client = {
+        isReady: () => true,
+        getDjsConfig: () => ({}),
+        application: {
+            commands: {
+                set: mockSet
+            }
+        }
+    } as any;
+
+    const handler = new ApplicationCommandHandler(client);
+    const guilds = Array.from({ length: 20 }, (_, i) => `guild-${i}`);
+    handler.setGuilds(guilds);
+
+    const start = performance.now();
+    await handler.sync();
+    const end = performance.now();
+
+    console.log(`Sync time for ${guilds.length} guilds: ${end - start}ms`);
+});


### PR DESCRIPTION
💡 **What:** The `ApplicationCommandHandler.sync()` method was optimized to register application commands to multiple guilds concurrently using `Promise.all` and `.map`, rather than sequentially.
🎯 **Why:** Registering commands sequentially via a `for` loop with an `await` causes a significant performance bottleneck when the bot is in multiple guilds. Network latency stacks linearly with the number of guilds. By executing these requests concurrently, we avoid this issue.
📊 **Measured Improvement:** A benchmark was created in `packages/runtime/test/application-command-handler.test.ts` to simulate registering commands to 20 guilds with a network delay of 50ms per request. The baseline execution time was ~1000ms. After this optimization, the time drops to ~60ms, resulting in an improvement of more than 16x over the baseline.

---
*PR created automatically by Jules for task [8796837047346278865](https://jules.google.com/task/8796837047346278865) started by @Cleboost*