### PR TITLE
🔒 fix(sql): Enforce parameterized template literals for SQL queries

### DIFF
--- a/.changeset/security-sql-injection-fix.md
+++ b/.changeset/security-sql-injection-fix.md
@@ -1,0 +1,6 @@
+---
+"@djs-core/plugin-sql": major
+---
+
+Enforce tagged template literals for SQL queries to prevent SQL injection by design.
+This is a breaking change that removes support for traditional `(query, params)` syntax in favor of safe-by-default backtick templates: ``sql.execute`SELECT...` ``.

--- a/app/src/events/ready.ts
+++ b/app/src/events/ready.ts
@@ -3,11 +3,11 @@ import { ActivityType, Events } from "discord.js";
 
 export default new EventListener().event(Events.ClientReady).run((client) => {
 	client.user.setActivity({ name: "🥖 bread", type: ActivityType.Custom });
-	client.sql.run(`
+	client.sql.run`
 		CREATE TABLE IF NOT EXISTS todos (
 			id INTEGER PRIMARY KEY AUTOINCREMENT,
 			task TEXT NOT NULL,
 			created_at DATETIME DEFAULT CURRENT_TIMESTAMP
 		)
-	`);
+	`;
 });

--- a/app/src/interactions/commands/ping.ts
+++ b/app/src/interactions/commands/ping.ts
@@ -3,7 +3,7 @@ import { Command } from "@djs-core/runtime";
 export default new Command()
 	.setDescription("Ping the bot")
 	.run(async (interaction) => {
-		const result = interaction.client.sql.execute("SELECT 1 as val");
+		const result = interaction.client.sql.execute`SELECT 1 as val`;
 		const message = interaction.client.demo.sayHello();
 		await interaction.reply(
 			`Pong! ${message}. SQL Test: ${JSON.stringify(result)}`,

--- a/app/src/interactions/commands/todo/add.ts
+++ b/app/src/interactions/commands/todo/add.ts
@@ -7,6 +7,6 @@ export default new Command()
 	)
 	.run(async (interaction) => {
 		const task = interaction.options.getString("task", true);
-		interaction.client.sql.run("INSERT INTO todos (task) VALUES (?)", [task]);
+		interaction.client.sql.run`INSERT INTO todos (task) VALUES (${task})`;
 		return interaction.reply(`✅ Added task: **${task}**`);
 	});

--- a/app/src/interactions/commands/todo/list.ts
+++ b/app/src/interactions/commands/todo/list.ts
@@ -3,9 +3,8 @@ import { Command } from "@djs-core/runtime";
 export default new Command()
 	.setDescription("List all your tasks")
 	.run(async (interaction) => {
-		const todos = interaction.client.sql.execute(
-			"SELECT * FROM todos ORDER BY created_at DESC",
-		) as {
+		const todos = interaction.client.sql
+			.execute`SELECT * FROM todos ORDER BY created_at DESC` as {
 			id: number;
 			task: string;
 			created_at: string;

--- a/app/src/interactions/commands/todo/remove.ts
+++ b/app/src/interactions/commands/todo/remove.ts
@@ -7,6 +7,6 @@ export default new Command()
 	)
 	.run(async (interaction) => {
 		const id = interaction.options.getInteger("id", true);
-		interaction.client.sql.run("DELETE FROM todos WHERE id = ?", [id]);
+		interaction.client.sql.run`DELETE FROM todos WHERE id = ${id}`;
 		return interaction.reply(`🗑️ Removed task with ID: \`#${id}\``);
 	});

--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "djs-core",
@@ -9,8 +8,8 @@
         "@changesets/cli": "^2.30.0",
         "dts-bundle-generator": "^9.5.1",
         "knip": "^5.86.0",
-        "typescript": "latest",
         "turbo": "^2.8.16",
+        "typescript": "latest",
       },
     },
     "app": {
@@ -26,7 +25,6 @@
       "devDependencies": {
         "@djs-core/dev": "workspace:*",
         "@types/bun": "latest",
-        "typescript": "latest",
       },
     },
     "packages/dev": {
@@ -72,7 +70,6 @@
       },
       "devDependencies": {
         "@types/bun": "latest",
-        "typescript": "^5",
       },
       "peerDependencies": {
         "discord.js": "^14.25.1",

--- a/plugins/plugin-sql/index.ts
+++ b/plugins/plugin-sql/index.ts
@@ -13,14 +13,14 @@ export const sqlPlugin = definePlugin({
 
 		return {
 			/**
-			 * Execute a raw SQL query.
+			 * Execute a raw SQL query using tagged templates.
 			 */
 			// biome-ignore lint/suspicious/noExplicitAny: raw SQL params
 			execute: (strings: TemplateStringsArray, ...params: any[]) => {
 				return db.query(strings.join("?")).all(...params);
 			},
 			/**
-			 * Execute a SQL statement and return no results.
+			 * Execute a SQL statement and return no results using tagged templates.
 			 */
 			// biome-ignore lint/suspicious/noExplicitAny: raw SQL params
 			run: (strings: TemplateStringsArray, ...params: any[]) => {

--- a/plugins/plugin-sql/index.ts
+++ b/plugins/plugin-sql/index.ts
@@ -16,15 +16,15 @@ export const sqlPlugin = definePlugin({
 			 * Execute a raw SQL query.
 			 */
 			// biome-ignore lint/suspicious/noExplicitAny: raw SQL params
-			execute: (query: string, params: any[] = []) => {
-				return db.query(query).all(...params);
+			execute: (strings: TemplateStringsArray, ...params: any[]) => {
+				return db.query(strings.join("?")).all(...params);
 			},
 			/**
 			 * Execute a SQL statement and return no results.
 			 */
 			// biome-ignore lint/suspicious/noExplicitAny: raw SQL params
-			run: (query: string, params: any[] = []) => {
-				return db.run(query, ...params);
+			run: (strings: TemplateStringsArray, ...params: any[]) => {
+				return db.run(strings.join("?"), ...params);
 			},
 			/**
 			 * Close the database connection.
@@ -38,8 +38,8 @@ export const sqlPlugin = definePlugin({
 		return `declare module "@djs-core/runtime" {
   interface PluginsExtensions {
     sql: {
-      execute: (query: string, params?: any[]) => any[];
-      run: (query: string, params?: any[]) => void;
+      execute: (strings: TemplateStringsArray, ...params: any[]) => any[];
+      run: (strings: TemplateStringsArray, ...params: any[]) => void;
       close: () => void;
     };
   }


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
The `execute` and `run` methods in the SQL plugin (`plugins/plugin-sql/index.ts`) accepted raw string queries, which allowed for potential SQL injection if user input was directly concatenated into the query string.

⚠️ **Risk:** The potential impact if left unfixed
An attacker could craft inputs that execute arbitrary SQL commands. Depending on the bot's permissions and available tables, this could lead to data extraction, manipulation, or unauthorized actions on the database, risking the integrity of user and application data.

🛡️ **Solution:** How the fix addresses the vulnerability
The method signatures for `execute` and `run` were changed to accept a `TemplateStringsArray` alongside the rest parameters. This effectively forces the use of tagged template literals (e.g., ``sql.execute`SELECT * FROM users WHERE id = ${id}```), which natively separates the static query string from the dynamic user input parameters, sending them securely to the underlying SQLite driver and neutralizing the SQL injection vector. All instances of string/function invocation in the application code were updated accordingly.

---
*PR created automatically by Jules for task [8381579321906165371](https://jules.google.com/task/8381579321906165371) started by @Cleboost*