### PR TITLE
⚡ Optimize ContextMenuHandler command operations with parallelization

### DIFF
--- a/.changeset/optimize-context-menu-handler.md
+++ b/.changeset/optimize-context-menu-handler.md
@@ -1,0 +1,5 @@
+---
+"@djs-core/runtime": patch
+---
+
+Optimize context menu registration and deletion by parallelizing guild-specific API calls and improving internal safety checks.

--- a/packages/runtime/handler/ContextMenuHandler.ts
+++ b/packages/runtime/handler/ContextMenuHandler.ts
@@ -29,9 +29,11 @@ export default class ContextMenuHandler {
 		}
 
 		if (this.guilds.length > 0) {
-			for (const guildId of this.guilds) {
-				await this.client.application.commands.create(contextMenu, guildId);
-			}
+			await Promise.all(
+				this.guilds.map((guildId) =>
+					this.client.application!.commands.create(contextMenu, guildId),
+				),
+			);
 		} else {
 			await this.client.application.commands.create(contextMenu);
 		}
@@ -60,15 +62,17 @@ export default class ContextMenuHandler {
 		}
 
 		if (this.guilds.length > 0) {
-			for (const guildId of this.guilds) {
-				const commands = await this.client.application.commands.fetch({
-					guildId,
-				});
-				const command = commands.find((cmd) => cmd.name === name);
-				if (command) {
-					await this.client.application.commands.delete(command.id, guildId);
-				}
-			}
+			await Promise.all(
+				this.guilds.map(async (guildId) => {
+					const commands = await this.client.application!.commands.fetch({
+						guildId,
+					});
+					const command = commands.find((cmd) => cmd.name === name);
+					if (command) {
+						await this.client.application!.commands.delete(command.id, guildId);
+					}
+				}),
+			);
 		} else {
 			const commands = await this.client.application.commands.fetch();
 			const command = commands.find((cmd) => cmd.name === name);

--- a/packages/runtime/handler/ContextMenuHandler.ts
+++ b/packages/runtime/handler/ContextMenuHandler.ts
@@ -24,18 +24,19 @@ export default class ContextMenuHandler {
 		this.assertReady();
 		this.contextMenus.set(contextMenu.name, contextMenu);
 
-		if (!this.client.application) {
+		const application = this.client.application;
+		if (!application) {
 			throw new Error("Client application is not available");
 		}
 
 		if (this.guilds.length > 0) {
 			await Promise.all(
 				this.guilds.map((guildId) =>
-					this.client.application!.commands.create(contextMenu, guildId),
+					application.commands.create(contextMenu, guildId),
 				),
 			);
 		} else {
-			await this.client.application.commands.create(contextMenu);
+			await application.commands.create(contextMenu);
 		}
 	}
 
@@ -57,27 +58,28 @@ export default class ContextMenuHandler {
 
 		this.contextMenus.delete(name);
 
-		if (!this.client.application) {
+		const application = this.client.application;
+		if (!application) {
 			throw new Error("Client application is not available");
 		}
 
 		if (this.guilds.length > 0) {
 			await Promise.all(
 				this.guilds.map(async (guildId) => {
-					const commands = await this.client.application!.commands.fetch({
+					const commands = await application.commands.fetch({
 						guildId,
 					});
 					const command = commands.find((cmd) => cmd.name === name);
 					if (command) {
-						await this.client.application!.commands.delete(command.id, guildId);
+						await application.commands.delete(command.id, guildId);
 					}
 				}),
 			);
 		} else {
-			const commands = await this.client.application.commands.fetch();
+			const commands = await application.commands.fetch();
 			const command = commands.find((cmd) => cmd.name === name);
 			if (command) {
-				await this.client.application.commands.delete(command.id);
+				await application.commands.delete(command.id);
 			}
 		}
 	}


### PR DESCRIPTION
💡 **What:** Refactored `add` and `delete` methods in `ContextMenuHandler.ts` to use `Promise.all` for concurrent command creation and deletion across multiple guilds.
🎯 **Why:** Previously, these operations were performed sequentially in a loop, leading to unnecessary delays as each Discord API call had to finish before the next one started. Parallelizing these I/O-bound operations makes the process significantly faster, especially for bots with many guilds.
📊 **Measured Improvement:** A measured baseline was impractical due to environment limitations (missing `discord.js` and `bun install` timeouts). However, theoretical improvement is significant as the execution time for N guilds reduces from O(N * latency) to approximately O(latency) (within Discord rate limits). Discord.js handles rate limiting internally, so this change allows for more efficient request scheduling.

---
*PR created automatically by Jules for task [7977308039533388803](https://jules.google.com/task/7977308039533388803) started by @Cleboost*