### PR TITLE
🔒 Fix command injection vulnerability in plugin installation

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,6 +1,5 @@
 {
   "lockfileVersion": 1,
-  "configVersion": 1,
   "workspaces": {
     "": {
       "name": "djs-core",
@@ -9,8 +8,8 @@
         "@changesets/cli": "^2.30.0",
         "dts-bundle-generator": "^9.5.1",
         "knip": "^5.86.0",
-        "typescript": "latest",
         "turbo": "^2.8.16",
+        "typescript": "latest",
       },
     },
     "app": {
@@ -26,7 +25,6 @@
       "devDependencies": {
         "@djs-core/dev": "workspace:*",
         "@types/bun": "latest",
-        "typescript": "latest",
       },
     },
     "packages/dev": {
@@ -72,7 +70,6 @@
       },
       "devDependencies": {
         "@types/bun": "latest",
-        "typescript": "^5",
       },
       "peerDependencies": {
         "discord.js": "^14.25.1",

--- a/packages/dev/commands/plugin.ts
+++ b/packages/dev/commands/plugin.ts
@@ -118,7 +118,7 @@ export function registerPluginCommand(cli: CAC) {
 
 			const result = spawnSync("bun", ["add", fullName], {
 				stdio: "inherit",
-				shell: true,
+				shell: false,
 			});
 
 			if (result.status !== 0) {


### PR DESCRIPTION
🎯 **What:** Fixed a command injection vulnerability in the `plugin install` command.
⚠️ **Risk:** The previous implementation used `shell: true` with `spawnSync` while passing user-supplied input (`fullName`). This could allow an attacker to execute arbitrary shell commands on the host machine by providing a crafted plugin name containing shell metacharacters (e.g., `; rm -rf /`).
🛡️ **Solution:** Changed the `spawnSync` options to `shell: false`. Since arguments are already correctly passed as an array (`["add", fullName]`), the shell execution context is unnecessary, and this change safely passes the arguments directly to the executable.

---
*PR created automatically by Jules for task [18056261246604024802](https://jules.google.com/task/18056261246604024802) started by @Cleboost*