### PR TITLE
🔒 Remove insecure shell execution in spawnSync calls

### DIFF
--- a/.changeset/security-fix-shell-injection.md
+++ b/.changeset/security-fix-shell-injection.md
@@ -1,0 +1,6 @@
+---
+"@djs-core/dev": patch
+"@djs-core/plugin-prisma-sqlite": patch
+---
+
+Security fix: Disable shell execution in spawnSync calls to prevent potential command injection vulnerabilities.

--- a/.changeset/security-fix-shell-injection.md
+++ b/.changeset/security-fix-shell-injection.md
@@ -1,6 +1,0 @@
----
-"@djs-core/dev": patch
-"@djs-core/plugin-prisma-sqlite": patch
----
-
-Security fix: Disable shell execution in spawnSync calls to prevent potential command injection vulnerabilities.

--- a/packages/dev/commands/plugin.ts
+++ b/packages/dev/commands/plugin.ts
@@ -91,11 +91,15 @@ export function registerPluginCommand(cli: CAC) {
 			"Manage bot plugins (install, postinstall)",
 		)
 		.action(async (action: string, name: string) => {
-			if (!name || !/^(?:@[a-z0-9-*~][a-z0-9-*._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/.test(name)) {
+			if (
+				!name ||
+				!/^(?:@[a-z0-9-*~][a-z0-9-*._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/.test(
+					name,
+				)
+			) {
 				console.error(pc.red(`\n❌ Invalid plugin name: ${name}`));
 				process.exit(1);
 			}
-
 			const fullName = name.startsWith("@") ? name : `@djs-core/${name}`;
 			const projectRoot = process.cwd();
 

--- a/packages/dev/commands/plugin.ts
+++ b/packages/dev/commands/plugin.ts
@@ -118,7 +118,6 @@ export function registerPluginCommand(cli: CAC) {
 
 			const result = spawnSync("bun", ["add", fullName], {
 				stdio: "inherit",
-				shell: true,
 			});
 
 			if (result.status !== 0) {

--- a/packages/dev/commands/plugin.ts
+++ b/packages/dev/commands/plugin.ts
@@ -91,6 +91,11 @@ export function registerPluginCommand(cli: CAC) {
 			"Manage bot plugins (install, postinstall)",
 		)
 		.action(async (action: string, name: string) => {
+			if (!name || !/^(?:@[a-z0-9-*~][a-z0-9-*._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/.test(name)) {
+				console.error(pc.red(`\n❌ Invalid plugin name: ${name}`));
+				process.exit(1);
+			}
+
 			const fullName = name.startsWith("@") ? name : `@djs-core/${name}`;
 			const projectRoot = process.cwd();
 

--- a/plugins/plugin-prisma-sqlite/index.ts
+++ b/plugins/plugin-prisma-sqlite/index.ts
@@ -66,7 +66,6 @@ export const prismaPlugin = definePlugin({
 				if (action === "generate") {
 					spawnSync("bunx", ["prisma", "generate"], {
 						stdio: "inherit",
-						shell: true,
 					});
 					process.exit(0);
 				}
@@ -74,7 +73,6 @@ export const prismaPlugin = definePlugin({
 				if (action === "push") {
 					spawnSync("bunx", ["prisma", "db", "push"], {
 						stdio: "inherit",
-						shell: true,
 					});
 					process.exit(0);
 				}


### PR DESCRIPTION
### 🎯 What
Removed insecure shell execution configuration (`shell: true`) from `spawnSync` calls in `plugins/plugin-prisma-sqlite/index.ts` and `packages/dev/commands/plugin.ts`.

### ⚠️ Risk
Using `shell: true` when spawning processes with arguments that could potentially be influenced by external input (like action names or plugin names) can lead to shell injection vulnerabilities. This could allow an attacker to execute arbitrary commands on the system.

### 🛡️ Solution
The `shell: true` option was removed from `spawnSync` calls where it was not strictly necessary. Commands like `bun` and `bunx` are standard executables that can be invoked directly by the operating system's process creation API, bypassing the shell layer and its associated security risks.

---
*PR created automatically by Jules for task [15441779271430255521](https://jules.google.com/task/15441779271430255521) started by @Cleboost*