### PR TITLE
Add optional intents configuration in djs.config.ts

### DIFF
--- a/.changeset/free-hairs-talk.md
+++ b/.changeset/free-hairs-talk.md
@@ -1,0 +1,5 @@
+---
+"@djs-core/runtime": minor
+---
+
+Allow users to specify optional `intents` in `djs.config.ts`. If not provided, it defaults to `MessageContent`, `GuildMembers`, and `GuildPresences`.

--- a/app/djs.config.ts
+++ b/app/djs.config.ts
@@ -1,6 +1,6 @@
 import { demoPlugin } from "@djs-core/plugin-demo";
 import { defineConfig } from "@djs-core/runtime";
-import { InteractionContextType } from "discord.js";
+import {IntentsBitField, InteractionContextType} from "discord.js";
 
 if (!process.env.TOKEN) {
 	throw new Error("TOKEN environment variable is required");
@@ -12,6 +12,11 @@ const config = defineConfig({
 	commands: {
 		defaultContext: [InteractionContextType.Guild],
 	},
+	intents: [
+		IntentsBitField.Flags.MessageContent,
+		IntentsBitField.Flags.GuildMembers,
+		IntentsBitField.Flags.GuildPresences
+	],
 	experimental: {
 		cron: true,
 		userConfig: true,

--- a/app/djs.config.ts
+++ b/app/djs.config.ts
@@ -1,6 +1,6 @@
 import { demoPlugin } from "@djs-core/plugin-demo";
 import { defineConfig } from "@djs-core/runtime";
-import {IntentsBitField, InteractionContextType} from "discord.js";
+import { IntentsBitField, InteractionContextType } from "discord.js";
 
 if (!process.env.TOKEN) {
 	throw new Error("TOKEN environment variable is required");
@@ -15,7 +15,7 @@ const config = defineConfig({
 	intents: [
 		IntentsBitField.Flags.MessageContent,
 		IntentsBitField.Flags.GuildMembers,
-		IntentsBitField.Flags.GuildPresences
+		IntentsBitField.Flags.GuildPresences,
 	],
 	experimental: {
 		cron: true,

--- a/knip.json
+++ b/knip.json
@@ -22,6 +22,6 @@
 			"ignoreDependencies": ["dotenv", "prisma"]
 		}
 	},
-	"ignoreBinaries": [],
+	"ignoreBinaries": ["tail"],
 	"ignore": ["packages/utils/**"]
 }

--- a/packages/dev/test/build.test.ts
+++ b/packages/dev/test/build.test.ts
@@ -5,10 +5,12 @@ import { registerBuildCommand } from "../commands/build";
 test("build command registers without throwing", () => {
 	const cli = cac("djs-core-test");
 	expect(() => registerBuildCommand(cli)).not.toThrow();
+	// biome-ignore lint/suspicious/noExplicitAny: access cac internals for testing
 	const anyCli = cli as any;
 	const cmds = anyCli.commands || anyCli._commands || [];
 	const hasBuild =
 		Array.isArray(cmds) &&
+		// biome-ignore lint/suspicious/noExplicitAny: access cac internals for testing
 		cmds.some((c: any) => c?.name === "build" || c?.command === "build");
 
 	expect(hasBuild).toBeTruthy();

--- a/packages/runtime/DjsClient.ts
+++ b/packages/runtime/DjsClient.ts
@@ -58,7 +58,7 @@ export class DjsClient<
 			intents: djsConfig.intents ?? [
 				IntentsBitField.Flags.MessageContent,
 				IntentsBitField.Flags.GuildMembers,
-				IntentsBitField.Flags.GuildPresences
+				IntentsBitField.Flags.GuildPresences,
 			],
 		});
 		this.djsConfig = djsConfig;

--- a/packages/runtime/DjsClient.ts
+++ b/packages/runtime/DjsClient.ts
@@ -55,11 +55,10 @@ export class DjsClient<
 		userConfig,
 	}: { djsConfig: Config<Plugins>; userConfig?: UserConfig }) {
 		super({
-			intents: [
-				IntentsBitField.Flags.Guilds,
-				IntentsBitField.Flags.GuildMessages,
-				IntentsBitField.Flags.GuildMessageReactions,
-				IntentsBitField.Flags.GuildVoiceStates,
+			intents: djsConfig.intents ?? [
+				IntentsBitField.Flags.MessageContent,
+				IntentsBitField.Flags.GuildMembers,
+				IntentsBitField.Flags.GuildPresences
 			],
 		});
 		this.djsConfig = djsConfig;

--- a/packages/runtime/Plugin.ts
+++ b/packages/runtime/Plugin.ts
@@ -1,4 +1,9 @@
-import type { BitFieldResolvable, Client, GatewayIntentsString, InteractionContextType } from "discord.js";
+import type {
+	BitFieldResolvable,
+	Client,
+	GatewayIntentsString,
+	InteractionContextType,
+} from "discord.js";
 
 /**
  * Definition of a djs-core plugin.

--- a/packages/runtime/Plugin.ts
+++ b/packages/runtime/Plugin.ts
@@ -1,4 +1,4 @@
-import type { Client, InteractionContextType } from "discord.js";
+import type { BitFieldResolvable, Client, GatewayIntentsString, InteractionContextType } from "discord.js";
 
 /**
  * Definition of a djs-core plugin.
@@ -51,6 +51,7 @@ export function definePlugin<Name extends string, Config, Extension>(
 interface CoreConfig {
 	token: string;
 	servers: string[];
+	intents?: BitFieldResolvable<GatewayIntentsString, number>;
 	commands?: {
 		defaultContext?: InteractionContextType[];
 	};

--- a/packages/utils/types/config.d.ts
+++ b/packages/utils/types/config.d.ts
@@ -1,4 +1,8 @@
-import type { BitFieldResolvable, GatewayIntentsString, InteractionContextType } from "discord.js";
+import type {
+	BitFieldResolvable,
+	GatewayIntentsString,
+	InteractionContextType,
+} from "discord.js";
 import type { PluginsConfigMap } from "../../runtime/Plugin";
 
 // biome-ignore lint/suspicious/noExplicitAny: generic plugin array

--- a/packages/utils/types/config.d.ts
+++ b/packages/utils/types/config.d.ts
@@ -1,10 +1,11 @@
-import type { InteractionContextType } from "discord.js";
+import type { BitFieldResolvable, GatewayIntentsString, InteractionContextType } from "discord.js";
 import type { PluginsConfigMap } from "../../runtime/Plugin";
 
 // biome-ignore lint/suspicious/noExplicitAny: generic plugin array
 export interface Config<P extends readonly any[] = any[]> {
 	token: string;
 	servers: string[];
+	intents?: BitFieldResolvable<GatewayIntentsString, number>;
 	commands?: {
 		defaultContext?: InteractionContextType[];
 	};


### PR DESCRIPTION
This pull request introduces support for optional Discord gateway intents in the `djs.config.ts` configuration. Users can now specify which intents their bot should use; if not provided, a sensible default set of intents is used. This makes the bot configuration more flexible and better aligned with Discord best practices.

**Configurable Discord Intents:**

* Added an optional `intents` field to the `CoreConfig` interface in `Plugin.ts`, allowing users to specify gateway intents in their config.
* Updated `DjsClient` to use the provided `intents` from config if available, otherwise defaulting to `MessageContent`, `GuildMembers`, and `GuildPresences` intents.
* Updated imports in `djs.config.ts` and `Plugin.ts` to support the new intent types. [[1]](diffhunk://#diff-064758bf88a5a516373df9bbc79c0ecfc14f9c119d1cf78f14d62bac093c3675L3-R3) [[2]](diffhunk://#diff-75fa32971604aa39ee9fca6fd164447940142032c84a66b953f3408ee0d8b69eL1-R1)

**Default Intents in Example Config:**

* Modified the example `djs.config.ts` to explicitly set the default intents, demonstrating the new configuration option.

**Documentation:**

* Added a changeset documenting the new optional `intents` configuration and its default behavior.