### PR TITLE
Enable all intents and support partials in configuration

### DIFF
--- a/.changeset/feat-enable-all-intents-and-logging.md
+++ b/.changeset/feat-enable-all-intents-and-logging.md
@@ -1,0 +1,8 @@
+---
+"@djs-core/runtime": minor
+---
+
+feat: add support for partials in configuration and enable all intents by default in `DjsClient`.
+- Add `partials` to the `Config` interface.
+- Update `DjsClient` constructor to include more default intents.
+- Added default `partials` support in `DjsClient` for partial data handling.

--- a/app/src/events/message.ts
+++ b/app/src/events/message.ts
@@ -1,0 +1,9 @@
+import { EventListener } from "@djs-core/runtime";
+import { Events } from "discord.js";
+
+export default new EventListener()
+	.event(Events.MessageCreate)
+	.run(async (_client, message) => {
+		if (message.author.bot) return;
+		console.log(message.content);
+	});

--- a/packages/runtime/DjsClient.ts
+++ b/packages/runtime/DjsClient.ts
@@ -77,7 +77,7 @@ export class DjsClient<
 				IntentsBitField.Flags.Guilds,
 				IntentsBitField.Flags.MessageContent,
 			],
-			partials: [
+			partials: djsConfig.partials ?? [
 				Partials.Channel,
 				Partials.User,
 				Partials.Reaction,

--- a/packages/runtime/DjsClient.ts
+++ b/packages/runtime/DjsClient.ts
@@ -10,6 +10,7 @@ import {
 	type Interaction,
 	type MentionableSelectMenuInteraction,
 	type ModalSubmitInteraction,
+	Partials,
 	type RoleSelectMenuInteraction,
 	type StringSelectMenuInteraction,
 	type UserSelectMenuInteraction,
@@ -56,9 +57,34 @@ export class DjsClient<
 	}: { djsConfig: Config<Plugins>; userConfig?: UserConfig }) {
 		super({
 			intents: djsConfig.intents ?? [
-				IntentsBitField.Flags.MessageContent,
+				IntentsBitField.Flags.DirectMessageReactions,
+				IntentsBitField.Flags.DirectMessageTyping,
+				IntentsBitField.Flags.DirectMessages,
+				IntentsBitField.Flags.GuildModeration,
+				IntentsBitField.Flags.GuildExpressions,
+				IntentsBitField.Flags.GuildIntegrations,
+				IntentsBitField.Flags.GuildIntegrations,
+				IntentsBitField.Flags.GuildInvites,
 				IntentsBitField.Flags.GuildMembers,
+				IntentsBitField.Flags.GuildMessageReactions,
+				IntentsBitField.Flags.GuildMessageTyping,
+				IntentsBitField.Flags.GuildMessages,
 				IntentsBitField.Flags.GuildPresences,
+				IntentsBitField.Flags.GuildScheduledEvents,
+				IntentsBitField.Flags.GuildScheduledEvents,
+				IntentsBitField.Flags.GuildVoiceStates,
+				IntentsBitField.Flags.GuildWebhooks,
+				IntentsBitField.Flags.Guilds,
+				IntentsBitField.Flags.MessageContent,
+			],
+			partials: [
+				Partials.Channel,
+				Partials.User,
+				Partials.Reaction,
+				Partials.Message,
+				Partials.GuildMember,
+				Partials.GuildScheduledEvent,
+				Partials.ThreadMember,
 			],
 		});
 		this.djsConfig = djsConfig;

--- a/packages/utils/types/config.d.ts
+++ b/packages/utils/types/config.d.ts
@@ -2,6 +2,7 @@ import type {
 	BitFieldResolvable,
 	GatewayIntentsString,
 	InteractionContextType,
+	Partials,
 } from "discord.js";
 import type { PluginsConfigMap } from "../../runtime/Plugin";
 
@@ -10,6 +11,7 @@ export interface Config<P extends readonly any[] = any[]> {
 	token: string;
 	servers: string[];
 	intents?: BitFieldResolvable<GatewayIntentsString, number>;
+	partials?: Partials[];
 	commands?: {
 		defaultContext?: InteractionContextType[];
 	};


### PR DESCRIPTION
This pull request introduces enhancements to the Discord.js client runtime by enabling all intents and adding support for partials by default, as well as adding a basic message event listener for logging non-bot messages. These changes improve the client's ability to handle a wider range of Discord events and partial data, making it more robust and extensible.

**Core enhancements to client configuration:**

* The `DjsClient` now enables all major Discord intents by default, allowing the client to listen to a broader set of events without extra configuration. [[1]](diffhunk://#diff-f29e82f9d735e78183e6d922bacb5d9ab7df7332ab1d1c6214b2dd02936c0170L59-R87) [[2]](diffhunk://#diff-793e7c0ca061096c4a163b328b84bd0d81dfb56185194515a74fb32990349703R1-R8)
* Added default support for `partials` in the `DjsClient` constructor, enabling the client to handle events with incomplete data (such as uncached messages or users). The `Config` interface now includes a `partials` property. [[1]](diffhunk://#diff-f29e82f9d735e78183e6d922bacb5d9ab7df7332ab1d1c6214b2dd02936c0170R13) [[2]](diffhunk://#diff-f29e82f9d735e78183e6d922bacb5d9ab7df7332ab1d1c6214b2dd02936c0170L59-R87) [[3]](diffhunk://#diff-793e7c0ca061096c4a163b328b84bd0d81dfb56185194515a74fb32990349703R1-R8)

**New event listener:**

* Added a `message` event listener in `app/src/events/message.ts` that logs the content of messages from non-bot users to the console.

**Configuration documentation:**

* Updated the changeset to document the new features: enabling all intents and adding partials support in configuration.