### PR TITLE
Enforce config.json presence when userConfig is enabled

### DIFF
--- a/packages/dev/commands/build.ts
+++ b/packages/dev/commands/build.ts
@@ -429,9 +429,9 @@ export function registerBuildCommand(cli: CAC) {
 				try {
 					await fs.copyFile(configJsonPath, outConfigJsonPath);
 					console.log(
-						pc.green("✓") + `  config.json copied to ${pc.bold("dist/")}`,
+						`${pc.green("✓")}  config.json copied to ${pc.bold("dist/")}`,
 					);
-				} catch (e) {
+				} catch (_e) {
 					console.error(pc.red("❌ Could not copy config.json to dist/"));
 					process.exit(1);
 				}

--- a/packages/dev/commands/build.ts
+++ b/packages/dev/commands/build.ts
@@ -247,10 +247,12 @@ ${
     if (await configFile.exists()) {
       userConfigData = await configFile.json();
     } else {
-      console.warn("⚠️  config.json not found at runtime");
+      console.error("❌ config.json not found at runtime");
+      process.exit(1);
     }
   } catch (e) {
     console.error("❌ Failed to load config.json:", e);
+    process.exit(1);
   }
   const client = new DjsClient<UserConfig>({ djsConfig: config, userConfig: userConfigData as UserConfig });`
 		: "  const client = new DjsClient({ djsConfig: config });"
@@ -430,7 +432,8 @@ export function registerBuildCommand(cli: CAC) {
 						pc.green("✓") + `  config.json copied to ${pc.bold("dist/")}`,
 					);
 				} catch (e) {
-					console.warn(pc.yellow("⚠️  Could not copy config.json to dist/"));
+					console.error(pc.red("❌ Could not copy config.json to dist/"));
+					process.exit(1);
 				}
 			}
 

--- a/packages/dev/utils/common.ts
+++ b/packages/dev/utils/common.ts
@@ -151,11 +151,12 @@ export async function runBot(projectPath: string) {
 			userConfig = JSON.parse(configJsonContent);
 			console.log(`${pc.green("✓")}  User config loaded`);
 		} catch (_error) {
-			console.warn(
-				pc.yellow(
-					"⚠️  userConfig is enabled but config.json not found or invalid",
+			console.error(
+				pc.red(
+					"❌ userConfig is enabled but config.json not found or invalid",
 				),
 			);
+			process.exit(1);
 		}
 	}
 

--- a/packages/dev/utils/common.ts
+++ b/packages/dev/utils/common.ts
@@ -152,9 +152,7 @@ export async function runBot(projectPath: string) {
 			console.log(`${pc.green("✓")}  User config loaded`);
 		} catch (_error) {
 			console.error(
-				pc.red(
-					"❌ userConfig is enabled but config.json not found or invalid",
-				),
+				pc.red("❌ userConfig is enabled but config.json not found or invalid"),
 			);
 			process.exit(1);
 		}


### PR DESCRIPTION
The PR addresses the user's request to strictly check for the presence of `config.json` at startup.

Key changes:
1.  **Development Mode (`packages/dev/utils/common.ts`):** Modified `runBot` to log an error and exit if `config.json` is missing or invalid when `userConfig` is enabled.
2.  **Build Mode (`packages/dev/commands/build.ts`):**
    *   Updated the generated bot's entry point template to exit with an error at runtime if the configuration file is missing.
    *   Updated the build-time file-copying logic to fail the build if `config.json` cannot be copied to the `dist/` directory.

These changes prevent the framework from defaulting to a state where a user-expected configuration is silently ignored.

Fixes #40

---
*PR created automatically by Jules for task [6806745962639474455](https://jules.google.com/task/6806745962639474455) started by @Cleboost*