### PR TITLE
refactor(dev): deduplicate scan functions and fix dev tooling bugs

### DIFF
--- a/.changeset/refactor-dev-tooling-deduplication.md
+++ b/.changeset/refactor-dev-tooling-deduplication.md
@@ -1,0 +1,11 @@
+---
+"@djs-core/dev": patch
+---
+
+Refactor dev tooling internals and fix several bugs.
+
+- Replace 6 near-identical `scan*` functions with a single generic `scanDir<T>`, reducing ~300 lines of duplication
+- Extract shared plugin resolution logic into `utils/plugin.ts`
+- Fix `-p/--path` option not capturing its value in the `dev` command
+- Remove unnecessary `usePolling` from chokidar (caused 300ms delay on Linux)
+- Fix confusing TDZ error when `djs.config.ts` fails to load (e.g. missing TOKEN)

--- a/app/src/interactions/commands/autocomplete.ts
+++ b/app/src/interactions/commands/autocomplete.ts
@@ -1,22 +1,22 @@
 import { Command } from "@djs-core/runtime";
 
 export default new Command()
-  .setDescription("Autocomplete command")
-  .addStringOption((option) =>
-    option
-      .setName("type")
-      .setDescription("The type of log to export")
-      .setRequired(true)
-      .setAutocomplete(true)
-  )
-  .run(async (interaction) => {
-    await interaction.reply("Autocomplete command");
-  })
-  .runAutocomplete(async (interaction) => {
-    return interaction.respond([
-      {
-        name: new Date().toISOString(),
-        value: "now",
-      },
-    ]);
-  });
+	.setDescription("Autocomplete command")
+	.addStringOption((option) =>
+		option
+			.setName("type")
+			.setDescription("The type of log to export")
+			.setRequired(true)
+			.setAutocomplete(true),
+	)
+	.run(async (interaction) => {
+		await interaction.reply("Autocomplete command");
+	})
+	.runAutocomplete(async (interaction) => {
+		return interaction.respond([
+			{
+				name: new Date().toISOString(),
+				value: "now",
+			},
+		]);
+	});

--- a/app/src/interactions/commands/autocomplete.ts
+++ b/app/src/interactions/commands/autocomplete.ts
@@ -1,22 +1,22 @@
 import { Command } from "@djs-core/runtime";
 
 export default new Command()
-	.setDescription("Autocomplete command")
-	.addStringOption((option) =>
-		option
-			.setName("type")
-			.setDescription("The type of log to export")
-			.setRequired(true)
-			.setAutocomplete(true),
-	)
-	.run(async (interaction) => {
-		await interaction.reply("Autocomplete command");
-	})
-	.runAutocomplete(async (interaction) => {
-		return interaction.respond([
-			{
-				name: new Date().toISOString(),
-				value: "now",
-			},
-		]);
-	});
+  .setDescription("Autocomplete command")
+  .addStringOption((option) =>
+    option
+      .setName("type")
+      .setDescription("The type of log to export")
+      .setRequired(true)
+      .setAutocomplete(true)
+  )
+  .run(async (interaction) => {
+    await interaction.reply("Autocomplete command");
+  })
+  .runAutocomplete(async (interaction) => {
+    return interaction.respond([
+      {
+        name: new Date().toISOString(),
+        value: "now",
+      },
+    ]);
+  });

--- a/packages/dev/commands/build.ts
+++ b/packages/dev/commands/build.ts
@@ -10,153 +10,153 @@ import { autoGenerateConfigTypes } from "../utils/config-type-generator";
 declare const Bun: typeof import("bun");
 
 type BuildOptions = {
-  path: string;
-  outdir: string;
-  minify: boolean;
-  compile?: boolean;
-  bundled?: boolean;
-  external?: boolean;
+	path: string;
+	outdir: string;
+	minify: boolean;
+	compile?: boolean;
+	bundled?: boolean;
+	external?: boolean;
 };
 
 function toPosixPath(p: string): string {
-  return p.split(path.sep).join("/");
+	return p.split(path.sep).join("/");
 }
 
 function ensureRelImport(p: string): string {
-  return p.startsWith(".") ? p : `./${p}`;
+	return p.startsWith(".") ? p : `./${p}`;
 }
 
 function routeFromFile(baseDir: string, absFile: string): string | null {
-  const rel = path.relative(baseDir, absFile);
-  const relNoExt = rel.replace(/\.ts$/i, "");
-  const parts = relNoExt.split(path.sep).filter(Boolean);
-  if (parts.length === 0) return null;
-  if (parts[parts.length - 1] === "index") parts.pop();
-  if (parts.length === 0) return null;
-  return parts.join(".");
+	const rel = path.relative(baseDir, absFile);
+	const relNoExt = rel.replace(/\.ts$/i, "");
+	const parts = relNoExt.split(path.sep).filter(Boolean);
+	if (parts.length === 0) return null;
+	if (parts[parts.length - 1] === "index") parts.pop();
+	if (parts.length === 0) return null;
+	return parts.join(".");
 }
 
 async function listTsFilesRecursive(dir: string): Promise<string[]> {
-  try {
-    await fs.access(dir);
-  } catch {
-    return [];
-  }
+	try {
+		await fs.access(dir);
+	} catch {
+		return [];
+	}
 
-  const out: string[] = [];
-  const entries = await fs.readdir(dir, { withFileTypes: true });
-  for (const e of entries) {
-    const full = path.join(dir, e.name);
-    if (e.isDirectory()) {
-      out.push(...(await listTsFilesRecursive(full)));
-    } else if (
-      e.isFile() &&
-      e.name.endsWith(".ts") &&
-      !e.name.endsWith(".d.ts")
-    ) {
-      out.push(full);
-    }
-  }
-  return out;
+	const out: string[] = [];
+	const entries = await fs.readdir(dir, { withFileTypes: true });
+	for (const e of entries) {
+		const full = path.join(dir, e.name);
+		if (e.isDirectory()) {
+			out.push(...(await listTsFilesRecursive(full)));
+		} else if (
+			e.isFile() &&
+			e.name.endsWith(".ts") &&
+			!e.name.endsWith(".d.ts")
+		) {
+			out.push(full);
+		}
+	}
+	return out;
 }
 
 function makeVar(
-  prefix: "cmd" | "btn" | "ctx" | "sel" | "evt" | "cron",
-  route: string
+	prefix: "cmd" | "btn" | "ctx" | "sel" | "evt" | "cron",
+	route: string,
 ): string {
-  const safe = route.replace(/[^a-zA-Z0-9_]+/g, "_");
-  return `${prefix}_${safe}`;
+	const safe = route.replace(/[^a-zA-Z0-9_]+/g, "_");
+	return `${prefix}_${safe}`;
 }
 
 type RouteEntry = { route: string; varName: string };
 
 function processFiles(
-  files: string[],
-  genDir: string,
-  prefix: "cmd" | "btn" | "ctx" | "sel" | "evt" | "cron",
-  getRoute: (f: string) => string | null
+	files: string[],
+	genDir: string,
+	prefix: "cmd" | "btn" | "ctx" | "sel" | "evt" | "cron",
+	getRoute: (f: string) => string | null,
 ): { importLines: string[]; entries: RouteEntry[] } {
-  const importLines: string[] = [];
-  const entries: RouteEntry[] = [];
-  for (const f of files) {
-    const route = getRoute(f);
-    if (!route) continue;
-    const varName = makeVar(prefix, route);
-    const rel = ensureRelImport(toPosixPath(path.relative(genDir, f)));
-    importLines.push(`import ${varName} from "${rel}";`);
-    entries.push({ route, varName });
-  }
-  entries.sort((a, b) => a.route.localeCompare(b.route));
-  return { importLines, entries };
+	const importLines: string[] = [];
+	const entries: RouteEntry[] = [];
+	for (const f of files) {
+		const route = getRoute(f);
+		if (!route) continue;
+		const varName = makeVar(prefix, route);
+		const rel = ensureRelImport(toPosixPath(path.relative(genDir, f)));
+		importLines.push(`import ${varName} from "${rel}";`);
+		entries.push({ route, varName });
+	}
+	entries.sort((a, b) => a.route.localeCompare(b.route));
+	return { importLines, entries };
 }
 
 function buildGeneratedEntry(opts: {
-  genDir: string;
-  commandsDir: string;
-  buttonsDir: string;
-  contextsDir: string;
-  selectsDir: string;
-  commandFiles: string[];
-  buttonFiles: string[];
-  contextFiles: string[];
-  selectFiles: string[];
-  eventFiles: string[];
-  cronFiles: string[];
-  hasCronEnabled: boolean;
-  hasUserConfigEnabled: boolean;
-  hasBundleEnabled: boolean;
+	genDir: string;
+	commandsDir: string;
+	buttonsDir: string;
+	contextsDir: string;
+	selectsDir: string;
+	commandFiles: string[];
+	buttonFiles: string[];
+	contextFiles: string[];
+	selectFiles: string[];
+	eventFiles: string[];
+	cronFiles: string[];
+	hasCronEnabled: boolean;
+	hasUserConfigEnabled: boolean;
+	hasBundleEnabled: boolean;
 }): string {
-  const { genDir, commandsDir, buttonsDir, contextsDir, selectsDir } = opts;
+	const { genDir, commandsDir, buttonsDir, contextsDir, selectsDir } = opts;
 
-  const cmds = processFiles(opts.commandFiles, genDir, "cmd", (f) =>
-    routeFromFile(commandsDir, f)
-  );
-  const btns = processFiles(opts.buttonFiles, genDir, "btn", (f) =>
-    routeFromFile(buttonsDir, f)
-  );
-  const ctxs = processFiles(opts.contextFiles, genDir, "ctx", (f) =>
-    routeFromFile(contextsDir, f)
-  );
-  const sels = processFiles(opts.selectFiles, genDir, "sel", (f) =>
-    routeFromFile(selectsDir, f)
-  );
-  const evts = processFiles(opts.eventFiles, genDir, "evt", (f) =>
-    path.basename(f, ".ts")
-  );
-  const crons = processFiles(opts.cronFiles, genDir, "cron", (f) =>
-    path.basename(f, ".ts")
-  );
+	const cmds = processFiles(opts.commandFiles, genDir, "cmd", (f) =>
+		routeFromFile(commandsDir, f),
+	);
+	const btns = processFiles(opts.buttonFiles, genDir, "btn", (f) =>
+		routeFromFile(buttonsDir, f),
+	);
+	const ctxs = processFiles(opts.contextFiles, genDir, "ctx", (f) =>
+		routeFromFile(contextsDir, f),
+	);
+	const sels = processFiles(opts.selectFiles, genDir, "sel", (f) =>
+		routeFromFile(selectsDir, f),
+	);
+	const evts = processFiles(opts.eventFiles, genDir, "evt", (f) =>
+		path.basename(f, ".ts"),
+	);
+	const crons = processFiles(opts.cronFiles, genDir, "cron", (f) =>
+		path.basename(f, ".ts"),
+	);
 
-  const allImports = [
-    ...cmds.importLines,
-    ...btns.importLines,
-    ...ctxs.importLines,
-    ...sels.importLines,
-    ...evts.importLines,
-    ...crons.importLines,
-  ];
+	const allImports = [
+		...cmds.importLines,
+		...btns.importLines,
+		...ctxs.importLines,
+		...sels.importLines,
+		...evts.importLines,
+		...crons.importLines,
+	];
 
-  const sortedCmds = cmds.entries;
-  const sortedBtns = btns.entries;
-  const sortedCtxs = ctxs.entries;
-  const sortedSels = sels.entries;
-  const sortedEvts = evts.entries;
-  const sortedCrons = crons.entries;
+	const sortedCmds = cmds.entries;
+	const sortedBtns = btns.entries;
+	const sortedCtxs = ctxs.entries;
+	const sortedSels = sels.entries;
+	const sortedEvts = evts.entries;
+	const sortedCrons = crons.entries;
 
-  return `/* Auto-generated by djs-core. Do not edit manually. */
+	return `/* Auto-generated by djs-core. Do not edit manually. */
 import path from "node:path";
 import config from "../djs.config.ts";
 import { DjsClient, type Route } from "@djs-core/runtime";
 import { Events } from "discord.js";
 ${
-  opts.hasUserConfigEnabled
-    ? 'import type { UserConfig } from "./config.types.ts";'
-    : ""
+	opts.hasUserConfigEnabled
+		? 'import type { UserConfig } from "./config.types.ts";'
+		: ""
 }
 ${
-  opts.hasUserConfigEnabled && opts.hasBundleEnabled
-    ? 'import userConfigData from "../config.json" with { type: "json" };'
-    : ""
+	opts.hasUserConfigEnabled && opts.hasBundleEnabled
+		? 'import userConfigData from "../config.json" with { type: "json" };'
+		: ""
 }
 
 ${allImports.join("\n")}
@@ -173,10 +173,10 @@ async function main() {
 
   const commands: Route[] = [
 ${sortedCmds
-  .map(
-    (c) => `    { route: ${JSON.stringify(c.route)}, command: ${c.varName} },`
-  )
-  .join("\n")}
+	.map(
+		(c) => `    { route: ${JSON.stringify(c.route)}, command: ${c.varName} },`,
+	)
+	.join("\n")}
   ];
 
   const buttons = [
@@ -184,43 +184,43 @@ ${sortedBtns.map((b) => `    ${b.varName},`).join("\n")}
   ];
 
 ${sortedBtns
-  .map((b) => `  ${b.varName}.setCustomId(${JSON.stringify(b.route)});`)
-  .join("\n")}
+	.map((b) => `  ${b.varName}.setCustomId(${JSON.stringify(b.route)});`)
+	.join("\n")}
 
   const contextMenus = [
 ${sortedCtxs.map((c) => `    ${c.varName},`).join("\n")}
   ];
 
 ${sortedCtxs
-  .map((c) => {
-    const parts = splitRoute(c.route);
-    const leaf = parts[parts.length - 1];
-    return `  ${c.varName}.setName(${JSON.stringify(leaf)});`;
-  })
-  .join("\n")}
+	.map((c) => {
+		const parts = splitRoute(c.route);
+		const leaf = parts[parts.length - 1];
+		return `  ${c.varName}.setName(${JSON.stringify(leaf)});`;
+	})
+	.join("\n")}
 
   const selectMenus = [
 ${sortedSels.map((s) => `    ${s.varName},`).join("\n")}
   ];
 
 ${sortedSels
-  .map((s) => `  ${s.varName}.setCustomId(${JSON.stringify(s.route)});`)
-  .join("\n")}
+	.map((s) => `  ${s.varName}.setCustomId(${JSON.stringify(s.route)});`)
+	.join("\n")}
 
   const events = {
 ${sortedEvts
-  .map((e) => `    ${JSON.stringify(e.route)}: ${e.varName},`)
-  .join("\n")}
+	.map((e) => `    ${JSON.stringify(e.route)}: ${e.varName},`)
+	.join("\n")}
   };
 
 ${
-  opts.hasCronEnabled && sortedCrons.length > 0
-    ? `  const tasks = new Map([
+	opts.hasCronEnabled && sortedCrons.length > 0
+		? `  const tasks = new Map([
 ${sortedCrons
-  .map((c) => `    [${JSON.stringify(c.route)}, ${c.varName}],`)
-  .join("\n")}
+	.map((c) => `    [${JSON.stringify(c.route)}, ${c.varName}],`)
+	.join("\n")}
   ]);`
-    : ""
+		: ""
 }
 
   // Load user config if enabled. The type assertion is safe because:
@@ -228,10 +228,10 @@ ${sortedCrons
   // 2. The UserConfig type is auto-generated from config.json structure
   // 3. Any runtime mismatch will be caught during bot initialization
 ${
-  opts.hasUserConfigEnabled
-    ? opts.hasBundleEnabled
-      ? "  const client = new DjsClient<UserConfig>({ djsConfig: config, userConfig: userConfigData as UserConfig });"
-      : `  let userConfigData: UserConfig | undefined;
+	opts.hasUserConfigEnabled
+		? opts.hasBundleEnabled
+			? "  const client = new DjsClient<UserConfig>({ djsConfig: config, userConfig: userConfigData as UserConfig });"
+			: `  let userConfigData: UserConfig | undefined;
   try {
     const configPath = path.join(process.cwd(), "config.json");
     const configFile = Bun.file(configPath);
@@ -244,7 +244,7 @@ ${
     console.error("❌ Failed to load config.json:", e);
   }
   const client = new DjsClient<UserConfig>({ djsConfig: config, userConfig: userConfigData as UserConfig });`
-    : "  const client = new DjsClient({ djsConfig: config });"
+		: "  const client = new DjsClient({ djsConfig: config });"
 }
 
   await client.waitForPlugins();
@@ -262,9 +262,9 @@ ${
     client.buttonsHandler.set(buttons);
     client.selectMenusHandler.set(selectMenus);
 ${
-  opts.hasCronEnabled && sortedCrons.length > 0
-    ? "    if (config.experimental?.cron && tasks.size > 0) {\n      client.cronHandler.set(tasks);\n    }"
-    : ""
+	opts.hasCronEnabled && sortedCrons.length > 0
+		? "    if (config.experimental?.cron && tasks.size > 0) {\n      client.cronHandler.set(tasks);\n    }"
+		: ""
 }
     console.log(\`✅ Bot online (\${client.user?.tag ?? "unknown"})\`);
   });
@@ -289,316 +289,317 @@ main();
 }
 
 export function registerBuildCommand(cli: CAC) {
-  cli
-    .command("build", "Build production bundle")
-    .option("-p, --path <path>", "Custom project path", { default: "." })
-    .option(
-      "-o, --outdir <outdir>",
-      "Output directory (relative to project root)",
-      { default: "dist" }
-    )
-    .option("--no-minify", "Disable minification")
-    .option("--bundled", "Bun (bundled)")
-    .option("--external", "Bun (external deps)")
-    .option("-c, --compile", "Compile to a standalone binary")
-    .action(async (options: BuildOptions) => {
-      console.log(banner);
+	cli
+		.command("build", "Build production bundle")
+		.option("-p, --path <path>", "Custom project path", { default: "." })
+		.option(
+			"-o, --outdir <outdir>",
+			"Output directory (relative to project root)",
+			{ default: "dist" },
+		)
+		.option("--no-minify", "Disable minification")
+		.option("--bundled", "Bun (bundled)")
+		.option("--external", "Bun (external deps)")
+		.option("-c, --compile", "Compile to a standalone binary")
+		.action(async (options: BuildOptions) => {
+			console.log(banner);
 
-      const botRoot = path.resolve(process.cwd(), options.path);
-      const genDir = path.join(botRoot, ".djscore");
-      const entryPath = path.join(genDir, "index.ts");
+			const botRoot = path.resolve(process.cwd(), options.path);
+			const genDir = path.join(botRoot, ".djscore");
+			const entryPath = path.join(genDir, "index.ts");
 
-      const commandsDir = path.join(
-        botRoot,
-        PATH_ALIASES.interactions,
-        "commands"
-      );
-      const buttonsDir = path.join(botRoot, PATH_ALIASES.components, "buttons");
-      const contextsDir = path.join(
-        botRoot,
-        PATH_ALIASES.interactions,
-        "contexts"
-      );
-      const selectsDir = path.join(botRoot, PATH_ALIASES.components, "selects");
-      const eventsDir = path.join(botRoot, PATH_ALIASES.events);
-      const cronDir = path.join(botRoot, "src", "cron");
+			const commandsDir = path.join(
+				botRoot,
+				PATH_ALIASES.interactions,
+				"commands",
+			);
+			const buttonsDir = path.join(botRoot, PATH_ALIASES.components, "buttons");
+			const contextsDir = path.join(
+				botRoot,
+				PATH_ALIASES.interactions,
+				"contexts",
+			);
+			const selectsDir = path.join(botRoot, PATH_ALIASES.components, "selects");
+			const eventsDir = path.join(botRoot, PATH_ALIASES.events);
+			const cronDir = path.join(botRoot, "src", "cron");
 
-      console.log(`${pc.cyan("ℹ")}  Project: ${pc.bold(botRoot)}`);
-      console.log(`${pc.cyan("ℹ")}  Generating: ${pc.bold(entryPath)}\n`);
+			console.log(`${pc.cyan("ℹ")}  Project: ${pc.bold(botRoot)}`);
+			console.log(`${pc.cyan("ℹ")}  Generating: ${pc.bold(entryPath)}\n`);
 
-      await fs.mkdir(genDir, { recursive: true });
+			await fs.mkdir(genDir, { recursive: true });
 
-      const commandFiles = await listTsFilesRecursive(commandsDir);
-      const buttonFiles = await listTsFilesRecursive(buttonsDir);
-      const contextFiles = await listTsFilesRecursive(contextsDir);
-      const selectFiles = await listTsFilesRecursive(selectsDir);
-      const eventFiles = await listTsFilesRecursive(eventsDir);
-      const cronFiles = await listTsFilesRecursive(cronDir);
+			const commandFiles = await listTsFilesRecursive(commandsDir);
+			const buttonFiles = await listTsFilesRecursive(buttonsDir);
+			const contextFiles = await listTsFilesRecursive(contextsDir);
+			const selectFiles = await listTsFilesRecursive(selectsDir);
+			const eventFiles = await listTsFilesRecursive(eventsDir);
+			const cronFiles = await listTsFilesRecursive(cronDir);
 
-      const configModule = await import(path.join(botRoot, "djs.config.ts"));
-      const config =
-        configModule.default as import("../../utils/types/config").Config;
-      const hasCronEnabled = config.experimental?.cron === true;
-      const hasUserConfigEnabled = config.experimental?.userConfig === true;
-      const hasBundleEnabled = config.experimental?.bundle === true;
+			const configModule = await import(path.join(botRoot, "djs.config.ts"));
+			const config =
+				configModule.default as import("../../utils/types/config").Config;
+			const hasCronEnabled = config.experimental?.cron === true;
+			const hasUserConfigEnabled = config.experimental?.userConfig === true;
+			const hasBundleEnabled = config.experimental?.bundle === true;
 
-      // Auto-generate config types
-      await autoGenerateConfigTypes(botRoot, config, true);
+			// Auto-generate config types
+			await autoGenerateConfigTypes(botRoot, config, true);
 
-      const code = buildGeneratedEntry({
-        genDir,
-        commandsDir,
-        buttonsDir,
-        contextsDir,
-        selectsDir,
-        commandFiles,
-        buttonFiles,
-        contextFiles,
-        selectFiles,
-        eventFiles,
-        cronFiles,
-        hasCronEnabled,
-        hasUserConfigEnabled,
-        hasBundleEnabled,
-      });
+			const code = buildGeneratedEntry({
+				genDir,
+				commandsDir,
+				buttonsDir,
+				contextsDir,
+				selectsDir,
+				commandFiles,
+				buttonFiles,
+				contextFiles,
+				selectFiles,
+				eventFiles,
+				cronFiles,
+				hasCronEnabled,
+				hasUserConfigEnabled,
+				hasBundleEnabled,
+			});
 
-      await fs.writeFile(entryPath, code, "utf8");
+			await fs.writeFile(entryPath, code, "utf8");
 
-      let buildType: string | null = null;
-      if (options.compile) buildType = "compile";
-      if (options.bundled) {
-        if (buildType) {
-          console.error(
-            pc.red(
-              "❌ Cannot combine build flags --bundled/--external/--compile"
-            )
-          );
-          process.exit(1);
-        }
-        buildType = "bun";
-      }
-      if (options.external) {
-        if (buildType) {
-          console.error(
-            pc.red(
-              "❌ Cannot combine build flags --bundled/--external/--compile"
-            )
-          );
-          process.exit(1);
-        }
-        buildType = "bun-external";
-      }
+			let buildType: string | null = null;
+			if (options.compile) buildType = "compile";
+			if (options.bundled) {
+				if (buildType) {
+					console.error(
+						pc.red(
+							"❌ Cannot combine build flags --bundled/--external/--compile",
+						),
+					);
+					process.exit(1);
+				}
+				buildType = "bun";
+			}
+			if (options.external) {
+				if (buildType) {
+					console.error(
+						pc.red(
+							"❌ Cannot combine build flags --bundled/--external/--compile",
+						),
+					);
+					process.exit(1);
+				}
+				buildType = "bun-external";
+			}
 
-      if (!buildType) {
-        buildType = (await select({
-          message: "Select build type:",
-          options: [
-            { value: "bun", label: "Bun (bundled)" },
-            { value: "bun-external", label: "Bun (external deps)" },
-            { value: "compile", label: "Compile (Native binary, ~90MB)" },
-            { value: "docker", label: "Docker" },
-          ],
-        })) as string;
-      }
+			if (!buildType) {
+				buildType = (await select({
+					message: "Select build type:",
+					options: [
+						{ value: "bun", label: "Bun (bundled)" },
+						{ value: "bun-external", label: "Bun (external deps)" },
+						{ value: "compile", label: "Compile (Native binary, ~90MB)" },
+						{ value: "docker", label: "Docker" },
+					],
+				})) as string;
+			}
 
-      if (!buildType) {
-        console.log(pc.red("❌ Build cancelled"));
-        process.exit(1);
-      }
+			if (!buildType) {
+				console.log(pc.red("❌ Build cancelled"));
+				process.exit(1);
+			}
 
-      const outdirAbs = path.resolve(botRoot, options.outdir);
+			const outdirAbs = path.resolve(botRoot, options.outdir);
 
-      try {
-        await fs.rm(outdirAbs, { recursive: true, force: true });
-      } catch {
-        // Ignore if directory doesn't exist
-      }
+			try {
+				await fs.rm(outdirAbs, { recursive: true, force: true });
+			} catch {
+				// Ignore if directory doesn't exist
+			}
 
-      await fs.mkdir(outdirAbs, { recursive: true });
+			await fs.mkdir(outdirAbs, { recursive: true });
 
-      if (hasUserConfigEnabled && !hasBundleEnabled) {
-        const configJsonPath = path.join(botRoot, "config.json");
-        const outConfigJsonPath = path.join(outdirAbs, "config.json");
-        try {
-          await fs.copyFile(configJsonPath, outConfigJsonPath);
-          console.log(
-            pc.green("✓") + `  config.json copied to ${pc.bold("dist/")}`
-          );
-        } catch (e) {
-          console.warn(pc.yellow("⚠️  Could not copy config.json to dist/"));
-        }
-      }
+			if (hasUserConfigEnabled && !hasBundleEnabled) {
+				const configJsonPath = path.join(botRoot, "config.json");
+				const outConfigJsonPath = path.join(outdirAbs, "config.json");
+				try {
+					await fs.copyFile(configJsonPath, outConfigJsonPath);
+					console.log(
+						pc.green("✓") + `  config.json copied to ${pc.bold("dist/")}`,
+					);
+				} catch (e) {
+					console.warn(pc.yellow("⚠️  Could not copy config.json to dist/"));
+				}
+			}
 
-      if (buildType === "compile") {
-        const exeName = process.platform === "win32" ? "bot.exe" : "bot";
-        const outputPath = path.join(outdirAbs, exeName);
+			if (buildType === "compile") {
+				const exeName = process.platform === "win32" ? "bot.exe" : "bot";
+				const outputPath = path.join(outdirAbs, exeName);
 
-        console.log(`${pc.cyan("ℹ")}  Compiling native binary...`);
+				console.log(`${pc.cyan("ℹ")}  Compiling native binary...`);
 
-        const buildArgs = [
-          "build",
-          entryPath,
-          "--compile",
-          "--outfile",
-          outputPath,
-        ];
+				const buildArgs = [
+					"build",
+					entryPath,
+					"--compile",
+					"--outfile",
+					outputPath,
+				];
 
-        if (options.minify !== false) {
-          buildArgs.push("--minify");
-        }
+				if (options.minify !== false) {
+					buildArgs.push("--minify");
+				}
 
-        const proc = Bun.spawn(["bun", ...buildArgs], {
-          stdout: "inherit",
-          stderr: "inherit",
-        });
+				const proc = Bun.spawn(["bun", ...buildArgs], {
+					stdout: "inherit",
+					stderr: "inherit",
+				});
 
-        const exitCode = await proc.exited;
+				const exitCode = await proc.exited;
 
-        if (exitCode !== 0) {
-          console.error(pc.red("\n❌ Compilation failed"));
-          process.exit(1);
-        }
+				if (exitCode !== 0) {
+					console.error(pc.red("\n❌ Compilation failed"));
+					process.exit(1);
+				}
 
-        const stats = await fs.stat(outputPath);
-        const sizeMB = (stats.size / (1024 * 1024)).toFixed(2);
+				const stats = await fs.stat(outputPath);
+				const sizeMB = (stats.size / (1024 * 1024)).toFixed(2);
 
-        console.log(
-          pc.green("\n✓") +
-            `  Build success: ${pc.bold(exeName)} (${sizeMB} MB)`
-        );
-        console.log(pc.dim(`  - ${outputPath}`));
-        console.log(
-          pc.dim(`\nTip: run your bot with: ./${options.outdir}/${exeName}\n`)
-        );
-        process.exit(0);
-      }
+				console.log(
+					pc.green("\n✓") +
+						`  Build success: ${pc.bold(exeName)} (${sizeMB} MB)`,
+				);
+				console.log(pc.dim(`  - ${outputPath}`));
+				console.log(
+					pc.dim(`\nTip: run your bot with: ./${options.outdir}/${exeName}\n`),
+				);
+				process.exit(0);
+			}
 
-      const botPackageJsonPath = path.join(botRoot, "package.json");
-      let externalDeps: string[] = [];
+			const botPackageJsonPath = path.join(botRoot, "package.json");
+			let externalDeps: string[] = [];
 
-      if (buildType === "bun-external") {
-        try {
-          const botPackageJson = JSON.parse(
-            await fs.readFile(botPackageJsonPath, "utf-8")
-          );
-          externalDeps = [
-            ...Object.keys(botPackageJson.dependencies || {}),
-            ...Object.keys(botPackageJson.peerDependencies || {}),
-            "discord.js",
-          ].filter((d) => d !== "@djs-core/runtime");
-        } catch (_e) {
-          console.warn(
-            pc.yellow(
-              "⚠️  Could not read package.json, using default externals"
-            )
-          );
-          externalDeps = ["discord.js"];
-        }
-      }
+			if (buildType === "bun-external") {
+				try {
+					const botPackageJson = JSON.parse(
+						await fs.readFile(botPackageJsonPath, "utf-8"),
+					);
+					externalDeps = [
+						...Object.keys(botPackageJson.dependencies || {}),
+						...Object.keys(botPackageJson.peerDependencies || {}),
+						"discord.js",
+					].filter((d) => d !== "@djs-core/runtime");
+				} catch (_e) {
+					console.warn(
+						pc.yellow(
+							"⚠️  Could not read package.json, using default externals",
+						),
+					);
+					externalDeps = ["discord.js"];
+				}
+			}
 
-      const result = await Bun.build({
-        entrypoints: [entryPath],
-        outdir: outdirAbs,
-        target: "bun",
-        minify: !!options.minify,
-        splitting: false,
-        sourcemap: "none",
-        external: buildType === "bun-external" ? externalDeps : [],
-      });
+			const result = await Bun.build({
+				entrypoints: [entryPath],
+				outdir: outdirAbs,
+				target: "bun",
+				minify: !!options.minify,
+				splitting: false,
+				sourcemap: "none",
+				external: buildType === "bun-external" ? externalDeps : [],
+			});
 
-      if (!result.success) {
-        console.error(pc.red("❌ Build failed"));
-        for (const log of result.logs) console.error(log);
-        process.exit(1);
-      }
+			if (!result.success) {
+				console.error(pc.red("❌ Build failed"));
+				for (const log of result.logs) console.error(log);
+				process.exit(1);
+			}
 
-      const outputs = result.outputs.map((o: { path: string }) => o.path);
-      const outputFile = path.join(outdirAbs, "index.js");
-      const stats = await fs.stat(outputFile);
-      const sizeKB = (stats.size / 1024).toFixed(2);
-      const sizeMB = (stats.size / (1024 * 1024)).toFixed(2);
-      const sizeDisplay =
-        stats.size > 1024 * 1024 ? `${sizeMB} MB` : `${sizeKB} KB`;
+			const outputs = result.outputs.map((o: { path: string }) => o.path);
+			const outputFile = path.join(outdirAbs, "index.js");
+			const stats = await fs.stat(outputFile);
+			const sizeKB = (stats.size / 1024).toFixed(2);
+			const sizeMB = (stats.size / (1024 * 1024)).toFixed(2);
+			const sizeDisplay =
+				stats.size > 1024 * 1024 ? `${sizeMB} MB` : `${sizeKB} KB`;
 
-      const totalSourceFiles =
-        commandFiles.length +
-        buttonFiles.length +
-        contextFiles.length +
-        selectFiles.length +
-        eventFiles.length;
+			const totalSourceFiles =
+				commandFiles.length +
+				buttonFiles.length +
+				contextFiles.length +
+				selectFiles.length +
+				eventFiles.length;
 
-      console.log(
-        pc.green("✓") +
-          `  Build success (${totalSourceFiles} file${
-            totalSourceFiles === 1 ? "" : "s"
-          } → ${outputs.length} output${
-            outputs.length === 1 ? "" : "s"
-          }, ${sizeDisplay})`
-      );
-      for (const p of outputs) console.log(pc.dim(`  - ${p}`));
+			console.log(
+				pc.green("✓") +
+					`  Build success (${totalSourceFiles} file${
+						totalSourceFiles === 1 ? "" : "s"
+					} → ${outputs.length} output${
+						outputs.length === 1 ? "" : "s"
+					}, ${sizeDisplay})`,
+			);
+			for (const p of outputs) console.log(pc.dim(`  - ${p}`));
 
-      if (buildType === "docker") {
-        const dockerfileContent = `FROM oven/bun:alpine
+			if (buildType === "docker") {
+				const dockerfileContent = `FROM oven/bun:alpine
 WORKDIR /app
 COPY index.js .
 CMD ["bun", "index.js"]
 `;
-        const dockerfilePath = path.join(outdirAbs, "Dockerfile");
-        await fs.writeFile(dockerfilePath, dockerfileContent, "utf8");
-        console.log(
-          `${pc.green("✓")}  Dockerfile created: ${pc.bold("Dockerfile")}`
-        );
-        console.log(
-          pc.dim(
-            `\nTip: build with: docker build -t my-bot ${options.outdir}\n`
-          )
-        );
-      } else if (buildType === "bun-external") {
-        try {
-          const botPackageJson = JSON.parse(
-            await fs.readFile(botPackageJsonPath, "utf-8")
-          );
-          const distPackageJson = {
-            name: botPackageJson.name || "bot",
-            version: botPackageJson.version || "1.0.0",
-            type: "module",
-            scripts: {
-              start: "bun index.js",
-            },
-            dependencies: botPackageJson.dependencies || {},
-            peerDependencies: botPackageJson.peerDependencies || {},
-          };
+				const dockerfilePath = path.join(outdirAbs, "Dockerfile");
+				await fs.writeFile(dockerfilePath, dockerfileContent, "utf8");
+				console.log(
+					`${pc.green("✓")}  Dockerfile created: ${pc.bold("Dockerfile")}`,
+				);
+				console.log(
+					pc.dim(
+						`\nTip: build with: docker build -t my-bot ${options.outdir}\n`,
+					),
+				);
+			} else if (buildType === "bun-external") {
+				try {
+					const botPackageJson = JSON.parse(
+						await fs.readFile(botPackageJsonPath, "utf-8"),
+					);
+					const distPackageJson = {
+						name: botPackageJson.name || "bot",
+						version: botPackageJson.version || "1.0.0",
+						type: "module",
+						scripts: {
+							start: "bun index.js",
+						},
+						dependencies: botPackageJson.dependencies || {},
+						peerDependencies: botPackageJson.peerDependencies || {},
+					};
 
-          const distPackageJsonPath = path.join(outdirAbs, "package.json");
-          await fs.writeFile(
-            distPackageJsonPath,
-            JSON.stringify(distPackageJson, null, 2),
-            "utf8"
-          );
-          console.log(
-            pc.green("✓") + `  package.json created: ${pc.bold("package.json")}`
-          );
-          console.log(
-            pc.dim(
-              `\nTip: install deps then run: cd ${options.outdir} && bun install && bun start\n`
-            )
-          );
-        } catch (_e) {
-          console.warn(pc.yellow("⚠️  Could not generate package.json"));
-          console.log(
-            pc.dim(
-              `\nTip: run with: bun ${path.join(options.outdir, "index.js")}\n`
-            )
-          );
-        }
-      } else {
-        console.log(
-          pc.dim(
-            `\nTip: run with: bun ${path.join(options.outdir, "index.js")}\n`
-          )
-        );
-      }
+					const distPackageJsonPath = path.join(outdirAbs, "package.json");
+					await fs.writeFile(
+						distPackageJsonPath,
+						JSON.stringify(distPackageJson, null, 2),
+						"utf8",
+					);
+					console.log(
+						pc.green("✓") +
+							`  package.json created: ${pc.bold("package.json")}`,
+					);
+					console.log(
+						pc.dim(
+							`\nTip: install deps then run: cd ${options.outdir} && bun install && bun start\n`,
+						),
+					);
+				} catch (_e) {
+					console.warn(pc.yellow("⚠️  Could not generate package.json"));
+					console.log(
+						pc.dim(
+							`\nTip: run with: bun ${path.join(options.outdir, "index.js")}\n`,
+						),
+					);
+				}
+			} else {
+				console.log(
+					pc.dim(
+						`\nTip: run with: bun ${path.join(options.outdir, "index.js")}\n`,
+					),
+				);
+			}
 
-      process.exit(0);
-    });
+			process.exit(0);
+		});
 }

--- a/packages/dev/commands/build.ts
+++ b/packages/dev/commands/build.ts
@@ -10,177 +10,156 @@ import { autoGenerateConfigTypes } from "../utils/config-type-generator";
 declare const Bun: typeof import("bun");
 
 type BuildOptions = {
-	path: string;
-	outdir: string;
-	minify: boolean;
-	compile?: boolean;
-	bundled?: boolean;
-	external?: boolean;
+  path: string;
+  outdir: string;
+  minify: boolean;
+  compile?: boolean;
+  bundled?: boolean;
+  external?: boolean;
 };
 
 function toPosixPath(p: string): string {
-	return p.split(path.sep).join("/");
+  return p.split(path.sep).join("/");
 }
 
 function ensureRelImport(p: string): string {
-	return p.startsWith(".") ? p : `./${p}`;
+  return p.startsWith(".") ? p : `./${p}`;
 }
 
 function routeFromFile(baseDir: string, absFile: string): string | null {
-	const rel = path.relative(baseDir, absFile);
-	const relNoExt = rel.replace(/\.ts$/i, "");
-	const parts = relNoExt.split(path.sep).filter(Boolean);
-	if (parts.length === 0) return null;
-	if (parts[parts.length - 1] === "index") parts.pop();
-	if (parts.length === 0) return null;
-	return parts.join(".");
+  const rel = path.relative(baseDir, absFile);
+  const relNoExt = rel.replace(/\.ts$/i, "");
+  const parts = relNoExt.split(path.sep).filter(Boolean);
+  if (parts.length === 0) return null;
+  if (parts[parts.length - 1] === "index") parts.pop();
+  if (parts.length === 0) return null;
+  return parts.join(".");
 }
 
 async function listTsFilesRecursive(dir: string): Promise<string[]> {
-	try {
-		await fs.access(dir);
-	} catch {
-		return [];
-	}
+  try {
+    await fs.access(dir);
+  } catch {
+    return [];
+  }
 
-	const out: string[] = [];
-	const entries = await fs.readdir(dir, { withFileTypes: true });
-	for (const e of entries) {
-		const full = path.join(dir, e.name);
-		if (e.isDirectory()) {
-			out.push(...(await listTsFilesRecursive(full)));
-		} else if (
-			e.isFile() &&
-			e.name.endsWith(".ts") &&
-			!e.name.endsWith(".d.ts")
-		) {
-			out.push(full);
-		}
-	}
-	return out;
+  const out: string[] = [];
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  for (const e of entries) {
+    const full = path.join(dir, e.name);
+    if (e.isDirectory()) {
+      out.push(...(await listTsFilesRecursive(full)));
+    } else if (
+      e.isFile() &&
+      e.name.endsWith(".ts") &&
+      !e.name.endsWith(".d.ts")
+    ) {
+      out.push(full);
+    }
+  }
+  return out;
 }
 
 function makeVar(
-	prefix: "cmd" | "btn" | "ctx" | "sel" | "evt" | "cron",
-	route: string,
+  prefix: "cmd" | "btn" | "ctx" | "sel" | "evt" | "cron",
+  route: string
 ): string {
-	const safe = route.replace(/[^a-zA-Z0-9_]+/g, "_");
-	return `${prefix}_${safe}`;
+  const safe = route.replace(/[^a-zA-Z0-9_]+/g, "_");
+  return `${prefix}_${safe}`;
+}
+
+type RouteEntry = { route: string; varName: string };
+
+function processFiles(
+  files: string[],
+  genDir: string,
+  prefix: "cmd" | "btn" | "ctx" | "sel" | "evt" | "cron",
+  getRoute: (f: string) => string | null
+): { importLines: string[]; entries: RouteEntry[] } {
+  const importLines: string[] = [];
+  const entries: RouteEntry[] = [];
+  for (const f of files) {
+    const route = getRoute(f);
+    if (!route) continue;
+    const varName = makeVar(prefix, route);
+    const rel = ensureRelImport(toPosixPath(path.relative(genDir, f)));
+    importLines.push(`import ${varName} from "${rel}";`);
+    entries.push({ route, varName });
+  }
+  entries.sort((a, b) => a.route.localeCompare(b.route));
+  return { importLines, entries };
 }
 
 function buildGeneratedEntry(opts: {
-	genDir: string;
-	commandsDir: string;
-	buttonsDir: string;
-	contextsDir: string;
-	selectsDir: string;
-	commandFiles: string[];
-	buttonFiles: string[];
-	contextFiles: string[];
-	selectFiles: string[];
-	eventFiles: string[];
-	cronFiles: string[];
-	hasCronEnabled: boolean;
-	hasUserConfigEnabled: boolean;
-	hasBundleEnabled: boolean;
+  genDir: string;
+  commandsDir: string;
+  buttonsDir: string;
+  contextsDir: string;
+  selectsDir: string;
+  commandFiles: string[];
+  buttonFiles: string[];
+  contextFiles: string[];
+  selectFiles: string[];
+  eventFiles: string[];
+  cronFiles: string[];
+  hasCronEnabled: boolean;
+  hasUserConfigEnabled: boolean;
+  hasBundleEnabled: boolean;
 }): string {
-	const {
-		genDir,
-		commandsDir,
-		buttonsDir,
-		contextsDir,
-		selectsDir,
-		commandFiles,
-		buttonFiles,
-		contextFiles,
-		selectFiles,
-		eventFiles,
-	} = opts;
+  const { genDir, commandsDir, buttonsDir, contextsDir, selectsDir } = opts;
 
-	const imports: string[] = [];
-	const commandRoutes: Array<{ route: string; varName: string }> = [];
-	const buttonRoutes: Array<{ route: string; varName: string }> = [];
-	const contextRoutes: Array<{ route: string; varName: string }> = [];
-	const selectRoutes: Array<{ route: string; varName: string }> = [];
-	const eventRoutes: Array<{ id: string; varName: string }> = [];
-	const cronRoutes: Array<{ id: string; varName: string }> = [];
+  const cmds = processFiles(opts.commandFiles, genDir, "cmd", (f) =>
+    routeFromFile(commandsDir, f)
+  );
+  const btns = processFiles(opts.buttonFiles, genDir, "btn", (f) =>
+    routeFromFile(buttonsDir, f)
+  );
+  const ctxs = processFiles(opts.contextFiles, genDir, "ctx", (f) =>
+    routeFromFile(contextsDir, f)
+  );
+  const sels = processFiles(opts.selectFiles, genDir, "sel", (f) =>
+    routeFromFile(selectsDir, f)
+  );
+  const evts = processFiles(opts.eventFiles, genDir, "evt", (f) =>
+    path.basename(f, ".ts")
+  );
+  const crons = processFiles(opts.cronFiles, genDir, "cron", (f) =>
+    path.basename(f, ".ts")
+  );
 
-	for (const f of commandFiles) {
-		const route = routeFromFile(commandsDir, f);
-		if (!route) continue;
-		const varName = makeVar("cmd", route);
-		const rel = ensureRelImport(toPosixPath(path.relative(genDir, f)));
-		imports.push(`import ${varName} from "${rel}";`);
-		commandRoutes.push({ route, varName });
-	}
+  const allImports = [
+    ...cmds.importLines,
+    ...btns.importLines,
+    ...ctxs.importLines,
+    ...sels.importLines,
+    ...evts.importLines,
+    ...crons.importLines,
+  ];
 
-	for (const f of buttonFiles) {
-		const route = routeFromFile(buttonsDir, f);
-		if (!route) continue;
-		const varName = makeVar("btn", route);
-		const rel = ensureRelImport(toPosixPath(path.relative(genDir, f)));
-		imports.push(`import ${varName} from "${rel}";`);
-		buttonRoutes.push({ route, varName });
-	}
+  const sortedCmds = cmds.entries;
+  const sortedBtns = btns.entries;
+  const sortedCtxs = ctxs.entries;
+  const sortedSels = sels.entries;
+  const sortedEvts = evts.entries;
+  const sortedCrons = crons.entries;
 
-	for (const f of contextFiles) {
-		const route = routeFromFile(contextsDir, f);
-		if (!route) continue;
-		const varName = makeVar("ctx", route);
-		const rel = ensureRelImport(toPosixPath(path.relative(genDir, f)));
-		imports.push(`import ${varName} from "${rel}";`);
-		contextRoutes.push({ route, varName });
-	}
-
-	for (const f of selectFiles) {
-		const route = routeFromFile(selectsDir, f);
-		if (!route) continue;
-		const varName = makeVar("sel", route);
-		const rel = ensureRelImport(toPosixPath(path.relative(genDir, f)));
-		imports.push(`import ${varName} from "${rel}";`);
-		selectRoutes.push({ route, varName });
-	}
-
-	for (const f of eventFiles) {
-		const fileName = path.basename(f, ".ts");
-		const varName = makeVar("evt", fileName);
-		const rel = ensureRelImport(toPosixPath(path.relative(genDir, f)));
-		imports.push(`import ${varName} from "${rel}";`);
-		eventRoutes.push({ id: fileName, varName });
-	}
-
-	for (const f of opts.cronFiles) {
-		const fileName = path.basename(f, ".ts");
-		const varName = makeVar("cron", fileName);
-		const rel = ensureRelImport(toPosixPath(path.relative(genDir, f)));
-		imports.push(`import ${varName} from "${rel}";`);
-		cronRoutes.push({ id: fileName, varName });
-	}
-
-	const sortedCmds = commandRoutes.sort((a, b) =>
-		a.route.localeCompare(b.route),
-	);
-	const sortedBtns = buttonRoutes.sort((a, b) =>
-		a.route.localeCompare(b.route),
-	);
-	const sortedCtxs = contextRoutes.sort((a, b) =>
-		a.route.localeCompare(b.route),
-	);
-	const sortedSels = selectRoutes.sort((a, b) =>
-		a.route.localeCompare(b.route),
-	);
-	const sortedEvts = eventRoutes.sort((a, b) => a.id.localeCompare(b.id));
-	const sortedCrons = cronRoutes.sort((a, b) => a.id.localeCompare(b.id));
-
-	return `/* Auto-generated by djs-core. Do not edit manually. */
+  return `/* Auto-generated by djs-core. Do not edit manually. */
 import path from "node:path";
 import config from "../djs.config.ts";
 import { DjsClient, type Route } from "@djs-core/runtime";
 import { Events } from "discord.js";
-${opts.hasUserConfigEnabled ? 'import type { UserConfig } from "./config.types.ts";' : ""}
-${opts.hasUserConfigEnabled && opts.hasBundleEnabled ? 'import userConfigData from "../config.json" with { type: "json" };' : ""}
+${
+  opts.hasUserConfigEnabled
+    ? 'import type { UserConfig } from "./config.types.ts";'
+    : ""
+}
+${
+  opts.hasUserConfigEnabled && opts.hasBundleEnabled
+    ? 'import userConfigData from "../config.json" with { type: "json" };'
+    : ""
+}
 
-${imports.join("\n")}
+${allImports.join("\n")}
 
 function assertConfig(x: unknown): asserts x is { token: string; servers: string[] } {
   if (!x || typeof x !== "object") throw new Error("Invalid config: expected an object");
@@ -193,43 +172,55 @@ async function main() {
   assertConfig(config);
 
   const commands: Route[] = [
-${sortedCmds.map((c) => `    { route: ${JSON.stringify(c.route)}, command: ${c.varName} },`).join("\n")}
+${sortedCmds
+  .map(
+    (c) => `    { route: ${JSON.stringify(c.route)}, command: ${c.varName} },`
+  )
+  .join("\n")}
   ];
 
   const buttons = [
 ${sortedBtns.map((b) => `    ${b.varName},`).join("\n")}
   ];
 
-${sortedBtns.map((b) => `  ${b.varName}.setCustomId(${JSON.stringify(b.route)});`).join("\n")}
+${sortedBtns
+  .map((b) => `  ${b.varName}.setCustomId(${JSON.stringify(b.route)});`)
+  .join("\n")}
 
   const contextMenus = [
 ${sortedCtxs.map((c) => `    ${c.varName},`).join("\n")}
   ];
 
 ${sortedCtxs
-	.map((c) => {
-		const parts = splitRoute(c.route);
-		const leaf = parts[parts.length - 1];
-		return `  ${c.varName}.setName(${JSON.stringify(leaf)});`;
-	})
-	.join("\n")}
+  .map((c) => {
+    const parts = splitRoute(c.route);
+    const leaf = parts[parts.length - 1];
+    return `  ${c.varName}.setName(${JSON.stringify(leaf)});`;
+  })
+  .join("\n")}
 
   const selectMenus = [
 ${sortedSels.map((s) => `    ${s.varName},`).join("\n")}
   ];
 
-${sortedSels.map((s) => `  ${s.varName}.setCustomId(${JSON.stringify(s.route)});`).join("\n")}
+${sortedSels
+  .map((s) => `  ${s.varName}.setCustomId(${JSON.stringify(s.route)});`)
+  .join("\n")}
 
   const events = {
-${sortedEvts.map((e) => `    ${JSON.stringify(e.id)}: ${e.varName},`).join("\n")}
+${sortedEvts
+  .map((e) => `    ${JSON.stringify(e.route)}: ${e.varName},`)
+  .join("\n")}
   };
 
 ${
-	opts.hasCronEnabled && sortedCrons.length > 0
-		? `  const tasks = new Map([
-${sortedCrons.map((c) => `    [${JSON.stringify(c.id)}, ${c.varName}],`).join("\n")}
+  opts.hasCronEnabled && sortedCrons.length > 0
+    ? `  const tasks = new Map([
+${sortedCrons
+  .map((c) => `    [${JSON.stringify(c.route)}, ${c.varName}],`)
+  .join("\n")}
   ]);`
-		: ""
+    : ""
 }
 
   // Load user config if enabled. The type assertion is safe because:
@@ -237,10 +228,10 @@ ${sortedCrons.map((c) => `    [${JSON.stringify(c.id)}, ${c.varName}],`).join("\
   // 2. The UserConfig type is auto-generated from config.json structure
   // 3. Any runtime mismatch will be caught during bot initialization
 ${
-	opts.hasUserConfigEnabled
-		? opts.hasBundleEnabled
-			? "  const client = new DjsClient<UserConfig>({ djsConfig: config, userConfig: userConfigData as UserConfig });"
-			: `  let userConfigData: UserConfig | undefined;
+  opts.hasUserConfigEnabled
+    ? opts.hasBundleEnabled
+      ? "  const client = new DjsClient<UserConfig>({ djsConfig: config, userConfig: userConfigData as UserConfig });"
+      : `  let userConfigData: UserConfig | undefined;
   try {
     const configPath = path.join(process.cwd(), "config.json");
     const configFile = Bun.file(configPath);
@@ -253,7 +244,7 @@ ${
     console.error("❌ Failed to load config.json:", e);
   }
   const client = new DjsClient<UserConfig>({ djsConfig: config, userConfig: userConfigData as UserConfig });`
-		: "  const client = new DjsClient({ djsConfig: config });"
+    : "  const client = new DjsClient({ djsConfig: config });"
 }
 
   await client.waitForPlugins();
@@ -270,7 +261,11 @@ ${
     await client.applicationCommandHandler.sync();
     client.buttonsHandler.set(buttons);
     client.selectMenusHandler.set(selectMenus);
-${opts.hasCronEnabled && sortedCrons.length > 0 ? "    if (config.experimental?.cron && tasks.size > 0) {\n      client.cronHandler.set(tasks);\n    }" : ""}
+${
+  opts.hasCronEnabled && sortedCrons.length > 0
+    ? "    if (config.experimental?.cron && tasks.size > 0) {\n      client.cronHandler.set(tasks);\n    }"
+    : ""
+}
     console.log(\`✅ Bot online (\${client.user?.tag ?? "unknown"})\`);
   });
 
@@ -294,313 +289,316 @@ main();
 }
 
 export function registerBuildCommand(cli: CAC) {
-	cli
-		.command("build", "Build production bundle")
-		.option("-p, --path <path>", "Custom project path", { default: "." })
-		.option(
-			"-o, --outdir <outdir>",
-			"Output directory (relative to project root)",
-			{ default: "dist" },
-		)
-		.option("--no-minify", "Disable minification")
-		.option("--bundled", "Bun (bundled)")
-		.option("--external", "Bun (external deps)")
-		.option("-c, --compile", "Compile to a standalone binary")
-		.action(async (options: BuildOptions) => {
-			console.log(banner);
+  cli
+    .command("build", "Build production bundle")
+    .option("-p, --path <path>", "Custom project path", { default: "." })
+    .option(
+      "-o, --outdir <outdir>",
+      "Output directory (relative to project root)",
+      { default: "dist" }
+    )
+    .option("--no-minify", "Disable minification")
+    .option("--bundled", "Bun (bundled)")
+    .option("--external", "Bun (external deps)")
+    .option("-c, --compile", "Compile to a standalone binary")
+    .action(async (options: BuildOptions) => {
+      console.log(banner);
 
-			const botRoot = path.resolve(process.cwd(), options.path);
-			const genDir = path.join(botRoot, ".djscore");
-			const entryPath = path.join(genDir, "index.ts");
+      const botRoot = path.resolve(process.cwd(), options.path);
+      const genDir = path.join(botRoot, ".djscore");
+      const entryPath = path.join(genDir, "index.ts");
 
-			const commandsDir = path.join(
-				botRoot,
-				PATH_ALIASES.interactions,
-				"commands",
-			);
-			const buttonsDir = path.join(botRoot, PATH_ALIASES.components, "buttons");
-			const contextsDir = path.join(
-				botRoot,
-				PATH_ALIASES.interactions,
-				"contexts",
-			);
-			const selectsDir = path.join(botRoot, PATH_ALIASES.components, "selects");
-			const eventsDir = path.join(botRoot, PATH_ALIASES.events);
-			const cronDir = path.join(botRoot, "src", "cron");
+      const commandsDir = path.join(
+        botRoot,
+        PATH_ALIASES.interactions,
+        "commands"
+      );
+      const buttonsDir = path.join(botRoot, PATH_ALIASES.components, "buttons");
+      const contextsDir = path.join(
+        botRoot,
+        PATH_ALIASES.interactions,
+        "contexts"
+      );
+      const selectsDir = path.join(botRoot, PATH_ALIASES.components, "selects");
+      const eventsDir = path.join(botRoot, PATH_ALIASES.events);
+      const cronDir = path.join(botRoot, "src", "cron");
 
-			console.log(`${pc.cyan("ℹ")}  Project: ${pc.bold(botRoot)}`);
-			console.log(`${pc.cyan("ℹ")}  Generating: ${pc.bold(entryPath)}\n`);
+      console.log(`${pc.cyan("ℹ")}  Project: ${pc.bold(botRoot)}`);
+      console.log(`${pc.cyan("ℹ")}  Generating: ${pc.bold(entryPath)}\n`);
 
-			await fs.mkdir(genDir, { recursive: true });
+      await fs.mkdir(genDir, { recursive: true });
 
-			const commandFiles = await listTsFilesRecursive(commandsDir);
-			const buttonFiles = await listTsFilesRecursive(buttonsDir);
-			const contextFiles = await listTsFilesRecursive(contextsDir);
-			const selectFiles = await listTsFilesRecursive(selectsDir);
-			const eventFiles = await listTsFilesRecursive(eventsDir);
-			const cronFiles = await listTsFilesRecursive(cronDir);
+      const commandFiles = await listTsFilesRecursive(commandsDir);
+      const buttonFiles = await listTsFilesRecursive(buttonsDir);
+      const contextFiles = await listTsFilesRecursive(contextsDir);
+      const selectFiles = await listTsFilesRecursive(selectsDir);
+      const eventFiles = await listTsFilesRecursive(eventsDir);
+      const cronFiles = await listTsFilesRecursive(cronDir);
 
-			const configModule = await import(path.join(botRoot, "djs.config.ts"));
-			const config =
-				configModule.default as import("../../utils/types/config").Config;
-			const hasCronEnabled = config.experimental?.cron === true;
-			const hasUserConfigEnabled = config.experimental?.userConfig === true;
-			const hasBundleEnabled = config.experimental?.bundle === true;
+      const configModule = await import(path.join(botRoot, "djs.config.ts"));
+      const config =
+        configModule.default as import("../../utils/types/config").Config;
+      const hasCronEnabled = config.experimental?.cron === true;
+      const hasUserConfigEnabled = config.experimental?.userConfig === true;
+      const hasBundleEnabled = config.experimental?.bundle === true;
 
-			// Auto-generate config types
-			await autoGenerateConfigTypes(botRoot, config, true);
+      // Auto-generate config types
+      await autoGenerateConfigTypes(botRoot, config, true);
 
-			const code = buildGeneratedEntry({
-				genDir,
-				commandsDir,
-				buttonsDir,
-				contextsDir,
-				selectsDir,
-				commandFiles,
-				buttonFiles,
-				contextFiles,
-				selectFiles,
-				eventFiles,
-				cronFiles,
-				hasCronEnabled,
-				hasUserConfigEnabled,
-				hasBundleEnabled,
-			});
+      const code = buildGeneratedEntry({
+        genDir,
+        commandsDir,
+        buttonsDir,
+        contextsDir,
+        selectsDir,
+        commandFiles,
+        buttonFiles,
+        contextFiles,
+        selectFiles,
+        eventFiles,
+        cronFiles,
+        hasCronEnabled,
+        hasUserConfigEnabled,
+        hasBundleEnabled,
+      });
 
-			await fs.writeFile(entryPath, code, "utf8");
+      await fs.writeFile(entryPath, code, "utf8");
 
-			let buildType: string | null = null;
-			if (options.compile) buildType = "compile";
-			if (options.bundled) {
-				if (buildType) {
-					console.error(
-						pc.red(
-							"❌ Cannot combine build flags --bundled/--external/--compile",
-						),
-					);
-					process.exit(1);
-				}
-				buildType = "bun";
-			}
-			if (options.external) {
-				if (buildType) {
-					console.error(
-						pc.red(
-							"❌ Cannot combine build flags --bundled/--external/--compile",
-						),
-					);
-					process.exit(1);
-				}
-				buildType = "bun-external";
-			}
+      let buildType: string | null = null;
+      if (options.compile) buildType = "compile";
+      if (options.bundled) {
+        if (buildType) {
+          console.error(
+            pc.red(
+              "❌ Cannot combine build flags --bundled/--external/--compile"
+            )
+          );
+          process.exit(1);
+        }
+        buildType = "bun";
+      }
+      if (options.external) {
+        if (buildType) {
+          console.error(
+            pc.red(
+              "❌ Cannot combine build flags --bundled/--external/--compile"
+            )
+          );
+          process.exit(1);
+        }
+        buildType = "bun-external";
+      }
 
-			if (!buildType) {
-				buildType = (await select({
-					message: "Select build type:",
-					options: [
-						{ value: "bun", label: "Bun (bundled)" },
-						{ value: "bun-external", label: "Bun (external deps)" },
-						{ value: "compile", label: "Compile (Native binary, ~90MB)" },
-						{ value: "docker", label: "Docker" },
-					],
-				})) as string;
-			}
+      if (!buildType) {
+        buildType = (await select({
+          message: "Select build type:",
+          options: [
+            { value: "bun", label: "Bun (bundled)" },
+            { value: "bun-external", label: "Bun (external deps)" },
+            { value: "compile", label: "Compile (Native binary, ~90MB)" },
+            { value: "docker", label: "Docker" },
+          ],
+        })) as string;
+      }
 
-			if (!buildType) {
-				console.log(pc.red("❌ Build cancelled"));
-				process.exit(1);
-			}
+      if (!buildType) {
+        console.log(pc.red("❌ Build cancelled"));
+        process.exit(1);
+      }
 
-			const outdirAbs = path.resolve(botRoot, options.outdir);
+      const outdirAbs = path.resolve(botRoot, options.outdir);
 
-			try {
-				await fs.rm(outdirAbs, { recursive: true, force: true });
-			} catch {
-				// Ignore if directory doesn't exist
-			}
+      try {
+        await fs.rm(outdirAbs, { recursive: true, force: true });
+      } catch {
+        // Ignore if directory doesn't exist
+      }
 
-			await fs.mkdir(outdirAbs, { recursive: true });
+      await fs.mkdir(outdirAbs, { recursive: true });
 
-			if (hasUserConfigEnabled && !hasBundleEnabled) {
-				const configJsonPath = path.join(botRoot, "config.json");
-				const outConfigJsonPath = path.join(outdirAbs, "config.json");
-				try {
-					await fs.copyFile(configJsonPath, outConfigJsonPath);
-					console.log(
-						pc.green("✓") + `  config.json copied to ${pc.bold("dist/")}`,
-					);
-				} catch (e) {
-					console.warn(pc.yellow("⚠️  Could not copy config.json to dist/"));
-				}
-			}
+      if (hasUserConfigEnabled && !hasBundleEnabled) {
+        const configJsonPath = path.join(botRoot, "config.json");
+        const outConfigJsonPath = path.join(outdirAbs, "config.json");
+        try {
+          await fs.copyFile(configJsonPath, outConfigJsonPath);
+          console.log(
+            pc.green("✓") + `  config.json copied to ${pc.bold("dist/")}`
+          );
+        } catch (e) {
+          console.warn(pc.yellow("⚠️  Could not copy config.json to dist/"));
+        }
+      }
 
-			if (buildType === "compile") {
-				const exeName = process.platform === "win32" ? "bot.exe" : "bot";
-				const outputPath = path.join(outdirAbs, exeName);
+      if (buildType === "compile") {
+        const exeName = process.platform === "win32" ? "bot.exe" : "bot";
+        const outputPath = path.join(outdirAbs, exeName);
 
-				console.log(`${pc.cyan("ℹ")}  Compiling native binary...`);
+        console.log(`${pc.cyan("ℹ")}  Compiling native binary...`);
 
-				const buildArgs = [
-					"build",
-					entryPath,
-					"--compile",
-					"--outfile",
-					outputPath,
-				];
+        const buildArgs = [
+          "build",
+          entryPath,
+          "--compile",
+          "--outfile",
+          outputPath,
+        ];
 
-				if (options.minify !== false) {
-					buildArgs.push("--minify");
-				}
+        if (options.minify !== false) {
+          buildArgs.push("--minify");
+        }
 
-				const proc = Bun.spawn(["bun", ...buildArgs], {
-					stdout: "inherit",
-					stderr: "inherit",
-				});
+        const proc = Bun.spawn(["bun", ...buildArgs], {
+          stdout: "inherit",
+          stderr: "inherit",
+        });
 
-				const exitCode = await proc.exited;
+        const exitCode = await proc.exited;
 
-				if (exitCode !== 0) {
-					console.error(pc.red("\n❌ Compilation failed"));
-					process.exit(1);
-				}
+        if (exitCode !== 0) {
+          console.error(pc.red("\n❌ Compilation failed"));
+          process.exit(1);
+        }
 
-				const stats = await fs.stat(outputPath);
-				const sizeMB = (stats.size / (1024 * 1024)).toFixed(2);
+        const stats = await fs.stat(outputPath);
+        const sizeMB = (stats.size / (1024 * 1024)).toFixed(2);
 
-				console.log(
-					pc.green("\n✓") +
-						`  Build success: ${pc.bold(exeName)} (${sizeMB} MB)`,
-				);
-				console.log(pc.dim(`  - ${outputPath}`));
-				console.log(
-					pc.dim(`\nTip: run your bot with: ./${options.outdir}/${exeName}\n`),
-				);
-				process.exit(0);
-			}
+        console.log(
+          pc.green("\n✓") +
+            `  Build success: ${pc.bold(exeName)} (${sizeMB} MB)`
+        );
+        console.log(pc.dim(`  - ${outputPath}`));
+        console.log(
+          pc.dim(`\nTip: run your bot with: ./${options.outdir}/${exeName}\n`)
+        );
+        process.exit(0);
+      }
 
-			const botPackageJsonPath = path.join(botRoot, "package.json");
-			let externalDeps: string[] = [];
+      const botPackageJsonPath = path.join(botRoot, "package.json");
+      let externalDeps: string[] = [];
 
-			if (buildType === "bun-external") {
-				try {
-					const botPackageJson = JSON.parse(
-						await fs.readFile(botPackageJsonPath, "utf-8"),
-					);
-					externalDeps = [
-						...Object.keys(botPackageJson.dependencies || {}),
-						...Object.keys(botPackageJson.peerDependencies || {}),
-						"discord.js",
-					].filter((d) => d !== "@djs-core/runtime");
-				} catch (_e) {
-					console.warn(
-						pc.yellow(
-							"⚠️  Could not read package.json, using default externals",
-						),
-					);
-					externalDeps = ["discord.js"];
-				}
-			}
+      if (buildType === "bun-external") {
+        try {
+          const botPackageJson = JSON.parse(
+            await fs.readFile(botPackageJsonPath, "utf-8")
+          );
+          externalDeps = [
+            ...Object.keys(botPackageJson.dependencies || {}),
+            ...Object.keys(botPackageJson.peerDependencies || {}),
+            "discord.js",
+          ].filter((d) => d !== "@djs-core/runtime");
+        } catch (_e) {
+          console.warn(
+            pc.yellow(
+              "⚠️  Could not read package.json, using default externals"
+            )
+          );
+          externalDeps = ["discord.js"];
+        }
+      }
 
-			const result = await Bun.build({
-				entrypoints: [entryPath],
-				outdir: outdirAbs,
-				target: "bun",
-				minify: !!options.minify,
-				splitting: false,
-				sourcemap: "none",
-				external: buildType === "bun-external" ? externalDeps : [],
-			});
+      const result = await Bun.build({
+        entrypoints: [entryPath],
+        outdir: outdirAbs,
+        target: "bun",
+        minify: !!options.minify,
+        splitting: false,
+        sourcemap: "none",
+        external: buildType === "bun-external" ? externalDeps : [],
+      });
 
-			if (!result.success) {
-				console.error(pc.red("❌ Build failed"));
-				for (const log of result.logs) console.error(log);
-				process.exit(1);
-			}
+      if (!result.success) {
+        console.error(pc.red("❌ Build failed"));
+        for (const log of result.logs) console.error(log);
+        process.exit(1);
+      }
 
-			const outputs = result.outputs.map((o: { path: string }) => o.path);
-			const outputFile = path.join(outdirAbs, "index.js");
-			const stats = await fs.stat(outputFile);
-			const sizeKB = (stats.size / 1024).toFixed(2);
-			const sizeMB = (stats.size / (1024 * 1024)).toFixed(2);
-			const sizeDisplay =
-				stats.size > 1024 * 1024 ? `${sizeMB} MB` : `${sizeKB} KB`;
+      const outputs = result.outputs.map((o: { path: string }) => o.path);
+      const outputFile = path.join(outdirAbs, "index.js");
+      const stats = await fs.stat(outputFile);
+      const sizeKB = (stats.size / 1024).toFixed(2);
+      const sizeMB = (stats.size / (1024 * 1024)).toFixed(2);
+      const sizeDisplay =
+        stats.size > 1024 * 1024 ? `${sizeMB} MB` : `${sizeKB} KB`;
 
-			const totalSourceFiles =
-				commandFiles.length +
-				buttonFiles.length +
-				contextFiles.length +
-				selectFiles.length +
-				eventFiles.length;
+      const totalSourceFiles =
+        commandFiles.length +
+        buttonFiles.length +
+        contextFiles.length +
+        selectFiles.length +
+        eventFiles.length;
 
-			console.log(
-				pc.green("✓") +
-					`  Build success (${totalSourceFiles} file${totalSourceFiles === 1 ? "" : "s"} → ${outputs.length} output${outputs.length === 1 ? "" : "s"}, ${sizeDisplay})`,
-			);
-			for (const p of outputs) console.log(pc.dim(`  - ${p}`));
+      console.log(
+        pc.green("✓") +
+          `  Build success (${totalSourceFiles} file${
+            totalSourceFiles === 1 ? "" : "s"
+          } → ${outputs.length} output${
+            outputs.length === 1 ? "" : "s"
+          }, ${sizeDisplay})`
+      );
+      for (const p of outputs) console.log(pc.dim(`  - ${p}`));
 
-			if (buildType === "docker") {
-				const dockerfileContent = `FROM oven/bun:alpine
+      if (buildType === "docker") {
+        const dockerfileContent = `FROM oven/bun:alpine
 WORKDIR /app
 COPY index.js .
 CMD ["bun", "index.js"]
 `;
-				const dockerfilePath = path.join(outdirAbs, "Dockerfile");
-				await fs.writeFile(dockerfilePath, dockerfileContent, "utf8");
-				console.log(
-					`${pc.green("✓")}  Dockerfile created: ${pc.bold("Dockerfile")}`,
-				);
-				console.log(
-					pc.dim(
-						`\nTip: build with: docker build -t my-bot ${options.outdir}\n`,
-					),
-				);
-			} else if (buildType === "bun-external") {
-				try {
-					const botPackageJson = JSON.parse(
-						await fs.readFile(botPackageJsonPath, "utf-8"),
-					);
-					const distPackageJson = {
-						name: botPackageJson.name || "bot",
-						version: botPackageJson.version || "1.0.0",
-						type: "module",
-						scripts: {
-							start: "bun index.js",
-						},
-						dependencies: botPackageJson.dependencies || {},
-						peerDependencies: botPackageJson.peerDependencies || {},
-					};
+        const dockerfilePath = path.join(outdirAbs, "Dockerfile");
+        await fs.writeFile(dockerfilePath, dockerfileContent, "utf8");
+        console.log(
+          `${pc.green("✓")}  Dockerfile created: ${pc.bold("Dockerfile")}`
+        );
+        console.log(
+          pc.dim(
+            `\nTip: build with: docker build -t my-bot ${options.outdir}\n`
+          )
+        );
+      } else if (buildType === "bun-external") {
+        try {
+          const botPackageJson = JSON.parse(
+            await fs.readFile(botPackageJsonPath, "utf-8")
+          );
+          const distPackageJson = {
+            name: botPackageJson.name || "bot",
+            version: botPackageJson.version || "1.0.0",
+            type: "module",
+            scripts: {
+              start: "bun index.js",
+            },
+            dependencies: botPackageJson.dependencies || {},
+            peerDependencies: botPackageJson.peerDependencies || {},
+          };
 
-					const distPackageJsonPath = path.join(outdirAbs, "package.json");
-					await fs.writeFile(
-						distPackageJsonPath,
-						JSON.stringify(distPackageJson, null, 2),
-						"utf8",
-					);
-					console.log(
-						pc.green("✓") +
-							`  package.json created: ${pc.bold("package.json")}`,
-					);
-					console.log(
-						pc.dim(
-							`\nTip: install deps then run: cd ${options.outdir} && bun install && bun start\n`,
-						),
-					);
-				} catch (_e) {
-					console.warn(pc.yellow("⚠️  Could not generate package.json"));
-					console.log(
-						pc.dim(
-							`\nTip: run with: bun ${path.join(options.outdir, "index.js")}\n`,
-						),
-					);
-				}
-			} else {
-				console.log(
-					pc.dim(
-						`\nTip: run with: bun ${path.join(options.outdir, "index.js")}\n`,
-					),
-				);
-			}
+          const distPackageJsonPath = path.join(outdirAbs, "package.json");
+          await fs.writeFile(
+            distPackageJsonPath,
+            JSON.stringify(distPackageJson, null, 2),
+            "utf8"
+          );
+          console.log(
+            pc.green("✓") + `  package.json created: ${pc.bold("package.json")}`
+          );
+          console.log(
+            pc.dim(
+              `\nTip: install deps then run: cd ${options.outdir} && bun install && bun start\n`
+            )
+          );
+        } catch (_e) {
+          console.warn(pc.yellow("⚠️  Could not generate package.json"));
+          console.log(
+            pc.dim(
+              `\nTip: run with: bun ${path.join(options.outdir, "index.js")}\n`
+            )
+          );
+        }
+      } else {
+        console.log(
+          pc.dim(
+            `\nTip: run with: bun ${path.join(options.outdir, "index.js")}\n`
+          )
+        );
+      }
 
-			process.exit(0);
-		});
+      process.exit(0);
+    });
 }

--- a/packages/dev/commands/dev.ts
+++ b/packages/dev/commands/dev.ts
@@ -39,12 +39,13 @@ interface HandlerConfig {
 	) => Promise<void> | void;
 	unload: (route: string) => Promise<void> | void;
 	sync?: boolean;
+	unloadBeforeReload?: boolean;
 }
 
 export function registerDevCommand(cli: CAC) {
 	cli
 		.command("dev", "Start the bot in development mode")
-		.option("-p, --path", "Custom project path", { default: "." })
+		.option("-p, --path <path>", "Custom project path", { default: "." })
 		.action(async (options) => {
 			console.log(banner);
 			console.log(`${pc.cyan("ℹ")}  Starting development server...`);
@@ -162,6 +163,7 @@ export function registerDevCommand(cli: CAC) {
 						await client.commandsHandler.delete(route, true);
 					},
 					sync: true,
+					unloadBeforeReload: true,
 				},
 				{
 					label: "button",
@@ -190,6 +192,7 @@ export function registerDevCommand(cli: CAC) {
 					},
 					unload: async (route) => client.contextMenusHandler.delete(route),
 					sync: true,
+					unloadBeforeReload: true,
 				},
 				{
 					label: "select menu",
@@ -211,6 +214,7 @@ export function registerDevCommand(cli: CAC) {
 						client.selectMenusHandler.add(sm);
 					},
 					unload: async (route) => client.selectMenusHandler.delete(route),
+					unloadBeforeReload: true,
 				},
 				{
 					label: "modal",
@@ -226,6 +230,7 @@ export function registerDevCommand(cli: CAC) {
 						client.modalsHandler.add(modal);
 					},
 					unload: async (route) => client.modalsHandler.delete(route),
+					unloadBeforeReload: true,
 				},
 				{
 					label: "event",
@@ -239,6 +244,7 @@ export function registerDevCommand(cli: CAC) {
 					unload: async (id) => {
 						client.eventsHandler.remove(id);
 					},
+					unloadBeforeReload: true,
 				},
 			];
 
@@ -306,15 +312,7 @@ export function registerDevCommand(cli: CAC) {
 						`${pc.green(`✨ Reloading ${config.label}:`)} ${pc.bold(route)}`,
 					);
 
-					if (config.label === "event") {
-						await config.unload(route);
-					} else if (config.label === "context menu") {
-						await config.unload(route);
-					} else if (config.label === "select menu") {
-						await config.unload(route);
-					} else if (config.label === "route") {
-						await config.unload(route);
-					} else if (config.label === "modal") {
+					if (config.unloadBeforeReload) {
 						await config.unload(route);
 					}
 
@@ -368,9 +366,6 @@ export function registerDevCommand(cli: CAC) {
 				{
 					ignoreInitial: true,
 					ignored: /(^|[/\\])\../,
-					usePolling: true,
-					interval: 300,
-					binaryInterval: 300,
 				},
 			);
 

--- a/packages/dev/index.ts
+++ b/packages/dev/index.ts
@@ -8,6 +8,7 @@ import { registerDevCommand } from "./commands/dev";
 import { registerGenerateConfigTypesCommand } from "./commands/generate-config-types";
 import { registerPluginCommand } from "./commands/plugin";
 import { registerStartCommand } from "./commands/start";
+import { resolvePlugin } from "./utils/plugin";
 
 export type { Config };
 
@@ -27,24 +28,7 @@ async function run() {
 
 		if (config.plugins) {
 			for (const pluginInput of config.plugins) {
-				// biome-ignore lint/suspicious/noExplicitAny: dynamic plugin loading
-				let plugin: any;
-				if (
-					pluginInput instanceof Promise ||
-					(pluginInput &&
-						typeof pluginInput === "object" &&
-						"then" in pluginInput)
-				) {
-					const module = await pluginInput;
-					plugin = Object.values(module).find(
-						// biome-ignore lint/suspicious/noExplicitAny: dynamic plugin loading
-						(v: any) =>
-							v && typeof v === "object" && "name" in v && "setup" in v,
-					);
-				} else {
-					plugin = pluginInput;
-				}
-
+				const plugin = await resolvePlugin(pluginInput);
 				if (plugin?.cli) {
 					plugin.cli(cli);
 				}

--- a/packages/dev/utils/common.ts
+++ b/packages/dev/utils/common.ts
@@ -44,7 +44,11 @@ async function scanDir<T>(
 	dir: string,
 	prefix: string,
 	map: Map<string, string> | undefined,
-	process: (mod: { default: unknown }, route: string, fullPath: string) => T | null | undefined,
+	process: (
+		mod: { default: unknown },
+		route: string,
+		fullPath: string,
+	) => T | null | undefined,
 	recursive = true,
 ): Promise<T[]> {
 	try {
@@ -62,7 +66,11 @@ async function scanDir<T>(
 		if (recursive && entry.isDirectory()) {
 			const newPrefix = prefix ? `${prefix}.${entry.name}` : entry.name;
 			results.push(...(await scanDir(fullPath, newPrefix, map, process)));
-		} else if (entry.isFile() && entry.name.endsWith(".ts") && !entry.name.endsWith(".d.ts")) {
+		} else if (
+			entry.isFile() &&
+			entry.name.endsWith(".ts") &&
+			!entry.name.endsWith(".d.ts")
+		) {
 			const stem = entry.name.slice(0, -3);
 			let route: string;
 
@@ -95,7 +103,9 @@ export async function runBot(projectPath: string) {
 	const root = resolve(process.cwd(), projectPath);
 	let configModule: { default: unknown };
 	try {
-		configModule = await import(`${path.join(root, "djs.config.ts")}?t=${Date.now()}`);
+		configModule = await import(
+			`${path.join(root, "djs.config.ts")}?t=${Date.now()}`
+		);
 	} catch (err) {
 		throw new Error(
 			`Failed to load djs.config.ts: ${err instanceof Error ? err.message : String(err)}`,
@@ -126,14 +136,16 @@ export async function runBot(projectPath: string) {
 
 	const commands = await scanDir<Route>(
 		path.join(root, PATH_ALIASES.interactions, "commands"),
-		"", fileRouteMap,
+		"",
+		fileRouteMap,
 		(mod, route) => ({ route, command: mod.default as Command }),
 	);
 	console.log(`${pc.green("✓")}  Loaded ${pc.bold(commands.length)} commands`);
 
 	const buttons = await scanDir<Button>(
 		path.join(root, PATH_ALIASES.components, "buttons"),
-		"", buttonFileRouteMap,
+		"",
+		buttonFileRouteMap,
 		(mod, route) => {
 			const btn = mod.default as Button;
 			btn.setCustomId(route);
@@ -144,16 +156,20 @@ export async function runBot(projectPath: string) {
 
 	const eventEntries = await scanDir<[string, EventListener]>(
 		path.join(root, PATH_ALIASES.events),
-		"", eventFileIdMap,
+		"",
+		eventFileIdMap,
 		(mod, id) => [id, mod.default as EventListener],
 		false,
 	);
 	const events = Object.fromEntries(eventEntries);
-	console.log(`${pc.green("✓")}  Loaded ${pc.bold(eventEntries.length)} events`);
+	console.log(
+		`${pc.green("✓")}  Loaded ${pc.bold(eventEntries.length)} events`,
+	);
 
 	const contextMenus = await scanDir<ContextMenu>(
 		path.join(root, PATH_ALIASES.interactions, "contexts"),
-		"", contextMenuFileRouteMap,
+		"",
+		contextMenuFileRouteMap,
 		(mod, route) => {
 			const cm = mod.default as ContextMenu;
 			const leaf = getLeaf(route);
@@ -161,22 +177,28 @@ export async function runBot(projectPath: string) {
 			return cm;
 		},
 	);
-	console.log(`${pc.green("✓")}  Loaded ${pc.bold(contextMenus.length)} context menus`);
+	console.log(
+		`${pc.green("✓")}  Loaded ${pc.bold(contextMenus.length)} context menus`,
+	);
 
 	const selectMenus = await scanDir<SelectMenu>(
 		path.join(root, PATH_ALIASES.components, "selects"),
-		"", selectMenuFileRouteMap,
+		"",
+		selectMenuFileRouteMap,
 		(mod, route) => {
 			const sm = mod.default as SelectMenu;
 			if (!sm.data.custom_id) sm.setCustomId(route);
 			return sm;
 		},
 	);
-	console.log(`${pc.green("✓")}  Loaded ${pc.bold(selectMenus.length)} select menus`);
+	console.log(
+		`${pc.green("✓")}  Loaded ${pc.bold(selectMenus.length)} select menus`,
+	);
 
 	const modals = await scanDir<Modal>(
 		path.join(root, PATH_ALIASES.components, "modals"),
-		"", modalFileRouteMap,
+		"",
+		modalFileRouteMap,
 		(mod, route) => {
 			const modal = mod.default as Modal;
 			modal.setCustomId(route);
@@ -189,7 +211,8 @@ export async function runBot(projectPath: string) {
 	if (config.experimental?.cron) {
 		const cronEntries = await scanDir<[string, Task]>(
 			path.join(root, "src", "cron"),
-			"", cronFileIdMap,
+			"",
+			cronFileIdMap,
 			(mod, id) => [id, mod.default as Task],
 			false,
 		);
@@ -206,7 +229,9 @@ export async function runBot(projectPath: string) {
 			console.log(`${pc.green("✓")}  User config loaded`);
 		} catch {
 			console.warn(
-				pc.yellow("⚠️  userConfig is enabled but config.json not found or invalid"),
+				pc.yellow(
+					"⚠️  userConfig is enabled but config.json not found or invalid",
+				),
 			);
 		}
 	}
@@ -223,12 +248,16 @@ export async function runBot(projectPath: string) {
 	client.login(config.token).catch(
 		// biome-ignore lint/suspicious/noExplicitAny: error handling
 		(error: any) => {
-			console.error(`${pc.red("✗")} ${pc.bold("Failed to connect to Discord")}`);
+			console.error(
+				`${pc.red("✗")} ${pc.bold("Failed to connect to Discord")}`,
+			);
 			console.error(pc.dim("Error: ") + pc.red(error.message || String(error)));
 			if (error.message?.includes("token") || error.message?.includes("401")) {
 				console.error(
 					pc.yellow("\n💡 Tip: ") +
-						pc.dim("Vérifiez que votre token Discord est valide dans djs.config.ts"),
+						pc.dim(
+							"Vérifiez que votre token Discord est valide dans djs.config.ts",
+						),
 				);
 			}
 			process.exit(1);

--- a/packages/dev/utils/common.ts
+++ b/packages/dev/utils/common.ts
@@ -6,12 +6,12 @@ import {
 	DjsClient,
 	type DjsClientInstance,
 	type EventListener,
+	getLeaf,
 	type MentionableSelectMenu,
 	type Modal,
 	type RoleSelectMenu,
 	type Route,
 	type StringSelectMenu,
-	splitRoute,
 	type Task,
 	type UserSelectMenu,
 } from "@djs-core/runtime";
@@ -40,9 +40,67 @@ export const PATH_ALIASES = {
 	events: "src/events",
 } as const;
 
+async function scanDir<T>(
+	dir: string,
+	prefix: string,
+	map: Map<string, string> | undefined,
+	process: (mod: { default: unknown }, route: string, fullPath: string) => T | null | undefined,
+	recursive = true,
+): Promise<T[]> {
+	try {
+		await fs.access(dir);
+	} catch {
+		return [];
+	}
+
+	const results: T[] = [];
+	const entries = await fs.readdir(dir, { withFileTypes: true });
+
+	for (const entry of entries) {
+		const fullPath = path.join(dir, entry.name);
+
+		if (recursive && entry.isDirectory()) {
+			const newPrefix = prefix ? `${prefix}.${entry.name}` : entry.name;
+			results.push(...(await scanDir(fullPath, newPrefix, map, process)));
+		} else if (entry.isFile() && entry.name.endsWith(".ts") && !entry.name.endsWith(".d.ts")) {
+			const stem = entry.name.slice(0, -3);
+			let route: string;
+
+			if (recursive) {
+				if (stem === "index") {
+					if (!prefix) continue;
+					route = prefix;
+				} else {
+					route = prefix ? `${prefix}.${stem}` : stem;
+				}
+			} else {
+				route = stem;
+			}
+
+			const mod = await import(fullPath);
+			if (!mod.default) continue;
+
+			const result = process(mod as { default: unknown }, route, fullPath);
+			if (result == null) continue;
+
+			map?.set(fullPath, route);
+			results.push(result);
+		}
+	}
+
+	return results;
+}
+
 export async function runBot(projectPath: string) {
 	const root = resolve(process.cwd(), projectPath);
-	const configModule = await import(path.join(root, "djs.config.ts"));
+	let configModule: { default: unknown };
+	try {
+		configModule = await import(`${path.join(root, "djs.config.ts")}?t=${Date.now()}`);
+	} catch (err) {
+		throw new Error(
+			`Failed to load djs.config.ts: ${err instanceof Error ? err.message : String(err)}`,
+		);
+	}
 	const config = configModule.default as Config;
 	if (
 		!config ||
@@ -56,17 +114,8 @@ export async function runBot(projectPath: string) {
 	}
 
 	console.log(`${pc.green("✓")}  Config loaded`);
-
-	// Auto-generate config types
 	await autoGenerateConfigTypes(root, config);
 
-	const commands: Route[] = [];
-	const buttons: Button[] = [];
-	const contextMenus: ContextMenu[] = [];
-	const selectMenus: SelectMenu[] = [];
-	const modals: Modal[] = [];
-	const events: Record<string, EventListener> = {};
-	const tasks = new Map<string, Task>();
 	const fileRouteMap = new Map<string, string>();
 	const buttonFileRouteMap = new Map<string, string>();
 	const contextMenuFileRouteMap = new Map<string, string>();
@@ -75,71 +124,76 @@ export async function runBot(projectPath: string) {
 	const eventFileIdMap = new Map<string, string>();
 	const cronFileIdMap = new Map<string, string>();
 
-	commands.push(
-		...(await scanCommands(
-			path.join(root, PATH_ALIASES.interactions, "commands"),
-			"",
-			fileRouteMap,
-		)),
+	const commands = await scanDir<Route>(
+		path.join(root, PATH_ALIASES.interactions, "commands"),
+		"", fileRouteMap,
+		(mod, route) => ({ route, command: mod.default as Command }),
 	);
 	console.log(`${pc.green("✓")}  Loaded ${pc.bold(commands.length)} commands`);
 
-	buttons.push(
-		...(await scanButtons(
-			path.join(root, PATH_ALIASES.components, "buttons"),
-			"",
-			buttonFileRouteMap,
-		)),
+	const buttons = await scanDir<Button>(
+		path.join(root, PATH_ALIASES.components, "buttons"),
+		"", buttonFileRouteMap,
+		(mod, route) => {
+			const btn = mod.default as Button;
+			btn.setCustomId(route);
+			return btn;
+		},
 	);
 	console.log(`${pc.green("✓")}  Loaded ${pc.bold(buttons.length)} buttons`);
 
-	Object.assign(
-		events,
-		await scanEvents(path.join(root, PATH_ALIASES.events), eventFileIdMap),
+	const eventEntries = await scanDir<[string, EventListener]>(
+		path.join(root, PATH_ALIASES.events),
+		"", eventFileIdMap,
+		(mod, id) => [id, mod.default as EventListener],
+		false,
 	);
-	console.log(
-		`${pc.green("✓")}  Loaded ${pc.bold(Object.keys(events).length)} events`,
-	);
+	const events = Object.fromEntries(eventEntries);
+	console.log(`${pc.green("✓")}  Loaded ${pc.bold(eventEntries.length)} events`);
 
-	contextMenus.push(
-		...(await scanContextMenus(
-			path.join(root, PATH_ALIASES.interactions, "contexts"),
-			"",
-			contextMenuFileRouteMap,
-		)),
+	const contextMenus = await scanDir<ContextMenu>(
+		path.join(root, PATH_ALIASES.interactions, "contexts"),
+		"", contextMenuFileRouteMap,
+		(mod, route) => {
+			const cm = mod.default as ContextMenu;
+			const leaf = getLeaf(route);
+			if (leaf) cm.setName(leaf);
+			return cm;
+		},
 	);
-	console.log(
-		`${pc.green("✓")}  Loaded ${pc.bold(contextMenus.length)} context menus`,
-	);
+	console.log(`${pc.green("✓")}  Loaded ${pc.bold(contextMenus.length)} context menus`);
 
-	selectMenus.push(
-		...(await scanSelectMenus(
-			path.join(root, PATH_ALIASES.components, "selects"),
-			"",
-			selectMenuFileRouteMap,
-		)),
+	const selectMenus = await scanDir<SelectMenu>(
+		path.join(root, PATH_ALIASES.components, "selects"),
+		"", selectMenuFileRouteMap,
+		(mod, route) => {
+			const sm = mod.default as SelectMenu;
+			if (!sm.data.custom_id) sm.setCustomId(route);
+			return sm;
+		},
 	);
-	console.log(
-		`${pc.green("✓")}  Loaded ${pc.bold(selectMenus.length)} select menus`,
-	);
+	console.log(`${pc.green("✓")}  Loaded ${pc.bold(selectMenus.length)} select menus`);
 
-	modals.push(
-		...(await scanModals(
-			path.join(root, PATH_ALIASES.components, "modals"),
-			"",
-			modalFileRouteMap,
-		)),
+	const modals = await scanDir<Modal>(
+		path.join(root, PATH_ALIASES.components, "modals"),
+		"", modalFileRouteMap,
+		(mod, route) => {
+			const modal = mod.default as Modal;
+			modal.setCustomId(route);
+			return modal;
+		},
 	);
 	console.log(`${pc.green("✓")}  Loaded ${pc.bold(modals.length)} modals`);
 
+	const tasks = new Map<string, Task>();
 	if (config.experimental?.cron) {
-		const cronTasks = await scanCron(
+		const cronEntries = await scanDir<[string, Task]>(
 			path.join(root, "src", "cron"),
-			cronFileIdMap,
+			"", cronFileIdMap,
+			(mod, id) => [id, mod.default as Task],
+			false,
 		);
-		for (const [id, task] of cronTasks.entries()) {
-			tasks.set(id, task);
-		}
+		for (const [id, task] of cronEntries) tasks.set(id, task);
 		console.log(`${pc.green("✓")}  Loaded ${pc.bold(tasks.size)} cron tasks`);
 	}
 
@@ -150,11 +204,9 @@ export async function runBot(projectPath: string) {
 			const configJsonContent = await fs.readFile(configJsonPath, "utf-8");
 			userConfig = JSON.parse(configJsonContent);
 			console.log(`${pc.green("✓")}  User config loaded`);
-		} catch (_error) {
+		} catch {
 			console.warn(
-				pc.yellow(
-					"⚠️  userConfig is enabled but config.json not found or invalid",
-				),
+				pc.yellow("⚠️  userConfig is enabled but config.json not found or invalid"),
 			);
 		}
 	}
@@ -171,21 +223,18 @@ export async function runBot(projectPath: string) {
 	client.login(config.token).catch(
 		// biome-ignore lint/suspicious/noExplicitAny: error handling
 		(error: any) => {
-			console.error(
-				`${pc.red("✗")} ${pc.bold("Failed to connect to Discord")}`,
-			);
+			console.error(`${pc.red("✗")} ${pc.bold("Failed to connect to Discord")}`);
 			console.error(pc.dim("Error: ") + pc.red(error.message || String(error)));
 			if (error.message?.includes("token") || error.message?.includes("401")) {
 				console.error(
 					pc.yellow("\n💡 Tip: ") +
-						pc.dim(
-							"Vérifiez que votre token Discord est valide dans djs.config.ts",
-						),
+						pc.dim("Vérifiez que votre token Discord est valide dans djs.config.ts"),
 				);
 			}
 			process.exit(1);
 		},
 	);
+
 	client.once(Events.ClientReady, async () => {
 		client.commandsHandler.set(commands);
 		client.contextMenusHandler.set(contextMenus);
@@ -218,310 +267,4 @@ export async function runBot(projectPath: string) {
 		eventFileIdMap,
 		cronFileIdMap,
 	};
-}
-
-async function scanButtons(
-	dir: string,
-	prefix: string = "",
-	map?: Map<string, string>,
-): Promise<Button[]> {
-	const buttons: Button[] = [];
-	try {
-		await fs.access(dir);
-	} catch {
-		return [];
-	}
-
-	const entries = await fs.readdir(dir, { withFileTypes: true });
-
-	for (const entry of entries) {
-		const fullPath = path.join(dir, entry.name);
-
-		if (entry.isDirectory()) {
-			const newPrefix = prefix ? `${prefix}.${entry.name}` : entry.name;
-			buttons.push(...(await scanButtons(fullPath, newPrefix, map)));
-		} else if (entry.isFile() && entry.name.endsWith(".ts")) {
-			const mod = await import(fullPath);
-			const button = mod.default as Button;
-
-			const routeName = entry.name.replace(".ts", "");
-			let route = "";
-
-			if (routeName === "index") {
-				if (prefix) route = prefix;
-			} else {
-				route = prefix ? `${prefix}.${routeName}` : routeName;
-			}
-
-			if (!route) continue;
-
-			// derive customId from route for consistency
-			button.setCustomId(route);
-
-			if (map) map.set(fullPath, route);
-			buttons.push(button);
-		}
-	}
-
-	return buttons;
-}
-
-async function scanCommands(
-	dir: string,
-	prefix: string = "",
-	map?: Map<string, string>,
-): Promise<Route[]> {
-	const routes: Route[] = [];
-
-	try {
-		await fs.access(dir);
-	} catch {
-		return [];
-	}
-
-	const entries = await fs.readdir(dir, { withFileTypes: true });
-
-	for (const entry of entries) {
-		const fullPath = path.join(dir, entry.name);
-
-		if (entry.isDirectory()) {
-			const newPrefix = prefix ? `${prefix}.${entry.name}` : entry.name;
-			routes.push(...(await scanCommands(fullPath, newPrefix, map)));
-		} else if (entry.isFile() && entry.name.endsWith(".ts")) {
-			const commandModule = await import(fullPath);
-			const command = commandModule.default as Command;
-
-			const routeName = entry.name.replace(".ts", "");
-			let route = "";
-
-			if (routeName === "index") {
-				if (prefix) {
-					route = prefix;
-				}
-			} else {
-				route = prefix ? `${prefix}.${routeName}` : routeName;
-			}
-
-			if (route) {
-				if (map) map.set(fullPath, route);
-				routes.push({ route: route, command });
-			}
-		}
-	}
-	return routes;
-}
-
-async function scanEvents(
-	dir: string,
-	map?: Map<string, string>,
-): Promise<Record<string, EventListener>> {
-	const events: Record<string, EventListener> = {};
-
-	try {
-		await fs.access(dir);
-	} catch {
-		return {};
-	}
-
-	const entries = await fs.readdir(dir, { withFileTypes: true });
-
-	for (const entry of entries) {
-		const fullPath = path.join(dir, entry.name);
-
-		if (entry.isFile() && entry.name.endsWith(".ts")) {
-			const mod = await import(fullPath);
-			const event = mod.default as EventListener;
-
-			if (!event) continue;
-
-			const eventId = entry.name.replace(".ts", "");
-
-			if (map) map.set(fullPath, eventId);
-			events[eventId] = event;
-		}
-	}
-
-	return events;
-}
-
-async function scanContextMenus(
-	dir: string,
-	prefix: string = "",
-	map?: Map<string, string>,
-): Promise<ContextMenu[]> {
-	const contextMenus: ContextMenu[] = [];
-
-	try {
-		await fs.access(dir);
-	} catch {
-		return [];
-	}
-
-	const entries = await fs.readdir(dir, { withFileTypes: true });
-
-	for (const entry of entries) {
-		const fullPath = path.join(dir, entry.name);
-
-		if (entry.isDirectory()) {
-			const newPrefix = prefix ? `${prefix}.${entry.name}` : entry.name;
-			contextMenus.push(...(await scanContextMenus(fullPath, newPrefix, map)));
-		} else if (entry.isFile() && entry.name.endsWith(".ts")) {
-			const mod = await import(fullPath);
-			const contextMenu = mod.default as ContextMenu;
-
-			if (!contextMenu) continue;
-
-			const routeName = entry.name.replace(".ts", "");
-			let route = "";
-
-			if (routeName === "index") {
-				if (prefix) route = prefix;
-			} else {
-				route = prefix ? `${prefix}.${routeName}` : routeName;
-			}
-
-			if (!route) continue;
-
-			const parts = splitRoute(route);
-			const leaf = parts[parts.length - 1];
-			if (leaf) contextMenu.setName(leaf);
-
-			if (map) map.set(fullPath, route);
-			contextMenus.push(contextMenu);
-		}
-	}
-
-	return contextMenus;
-}
-
-async function scanSelectMenus(
-	dir: string,
-	prefix: string = "",
-	map?: Map<string, string>,
-): Promise<SelectMenu[]> {
-	const selectMenus: SelectMenu[] = [];
-
-	try {
-		await fs.access(dir);
-	} catch {
-		return [];
-	}
-
-	const entries = await fs.readdir(dir, { withFileTypes: true });
-
-	for (const entry of entries) {
-		const fullPath = path.join(dir, entry.name);
-
-		if (entry.isDirectory()) {
-			const newPrefix = prefix ? `${prefix}.${entry.name}` : entry.name;
-			selectMenus.push(...(await scanSelectMenus(fullPath, newPrefix, map)));
-		} else if (entry.isFile() && entry.name.endsWith(".ts")) {
-			const mod = await import(fullPath);
-			const selectMenu = mod.default as SelectMenu | undefined;
-
-			if (!selectMenu) continue;
-
-			const routeName = entry.name.replace(".ts", "");
-			let route = "";
-
-			if (routeName === "index") {
-				if (prefix) route = prefix;
-			} else {
-				route = prefix ? `${prefix}.${routeName}` : routeName;
-			}
-
-			if (!route) continue;
-
-			const customId = selectMenu.data.custom_id;
-			if (!customId) {
-				selectMenu.setCustomId(route);
-			}
-
-			if (map) map.set(fullPath, route);
-			selectMenus.push(selectMenu);
-		}
-	}
-
-	return selectMenus;
-}
-
-async function scanModals(
-	dir: string,
-	prefix: string = "",
-	map?: Map<string, string>,
-): Promise<Modal[]> {
-	const modals: Modal[] = [];
-
-	try {
-		await fs.access(dir);
-	} catch {
-		return [];
-	}
-
-	const entries = await fs.readdir(dir, { withFileTypes: true });
-
-	for (const entry of entries) {
-		const fullPath = path.join(dir, entry.name);
-
-		if (entry.isDirectory()) {
-			const newPrefix = prefix ? `${prefix}.${entry.name}` : entry.name;
-			modals.push(...(await scanModals(fullPath, newPrefix, map)));
-		} else if (entry.isFile() && entry.name.endsWith(".ts")) {
-			const mod = await import(fullPath);
-			const modal = mod.default as Modal | undefined;
-
-			if (!modal) continue;
-
-			const routeName = entry.name.replace(".ts", "");
-			let route = "";
-
-			if (routeName === "index") {
-				if (prefix) route = prefix;
-			} else {
-				route = prefix ? `${prefix}.${routeName}` : routeName;
-			}
-
-			if (!route) continue;
-
-			modal.setCustomId(route);
-
-			if (map) map.set(fullPath, route);
-			modals.push(modal);
-		}
-	}
-
-	return modals;
-}
-
-async function scanCron(
-	dir: string,
-	map?: Map<string, string>,
-): Promise<Map<string, Task>> {
-	const tasks = new Map<string, Task>();
-
-	try {
-		await fs.access(dir);
-	} catch {
-		return tasks;
-	}
-
-	const entries = await fs.readdir(dir, { withFileTypes: true });
-
-	for (const entry of entries) {
-		const fullPath = path.join(dir, entry.name);
-
-		if (entry.isFile() && entry.name.endsWith(".ts")) {
-			const mod = await import(fullPath);
-			const task = mod.default as Task | undefined;
-
-			if (!task) continue;
-
-			const taskId = entry.name.replace(".ts", "");
-
-			if (map) map.set(fullPath, taskId);
-			tasks.set(taskId, task);
-		}
-	}
-
-	return tasks;
 }

--- a/packages/dev/utils/config-type-generator.ts
+++ b/packages/dev/utils/config-type-generator.ts
@@ -157,6 +157,7 @@ async function ensureDiscordAugmentation(
 }
 
 import type { Config } from "../../utils/types/config";
+import { resolvePlugin } from "./plugin";
 
 /**
  * Collects and writes types provided by plugins.
@@ -178,20 +179,7 @@ async function generatePluginTypes(
 	const types: string[] = [];
 
 	for (const pluginInput of config.plugins) {
-		// biome-ignore lint/suspicious/noExplicitAny: dynamic plugin loading
-		let plugin: any;
-		if (
-			pluginInput instanceof Promise ||
-			(pluginInput && typeof pluginInput === "object" && "then" in pluginInput)
-		) {
-			const module = await pluginInput;
-			plugin = Object.values(module).find(
-				// biome-ignore lint/suspicious/noExplicitAny: dynamic plugin loading
-				(v: any) => v && typeof v === "object" && "name" in v && "setup" in v,
-			);
-		} else {
-			plugin = pluginInput;
-		}
+		const plugin = await resolvePlugin(pluginInput);
 
 		if (plugin?.types) {
 			const pluginTypes = await plugin.types({ root: projectRoot });

--- a/packages/dev/utils/plugin.ts
+++ b/packages/dev/utils/plugin.ts
@@ -1,0 +1,16 @@
+// biome-ignore lint/suspicious/noExplicitAny: dynamic plugin loading
+type ResolvedPlugin = any;
+
+export async function resolvePlugin(pluginInput: unknown): Promise<ResolvedPlugin> {
+	if (
+		pluginInput instanceof Promise ||
+		(pluginInput && typeof pluginInput === "object" && "then" in (pluginInput as object))
+	) {
+		const mod = await (pluginInput as Promise<unknown>);
+		return Object.values(mod as object).find(
+			// biome-ignore lint/suspicious/noExplicitAny: dynamic plugin loading
+			(v: any) => v && typeof v === "object" && "name" in v && "setup" in v,
+		);
+	}
+	return pluginInput;
+}

--- a/packages/dev/utils/plugin.ts
+++ b/packages/dev/utils/plugin.ts
@@ -1,10 +1,14 @@
 // biome-ignore lint/suspicious/noExplicitAny: dynamic plugin loading
 type ResolvedPlugin = any;
 
-export async function resolvePlugin(pluginInput: unknown): Promise<ResolvedPlugin> {
+export async function resolvePlugin(
+	pluginInput: unknown,
+): Promise<ResolvedPlugin> {
 	if (
 		pluginInput instanceof Promise ||
-		(pluginInput && typeof pluginInput === "object" && "then" in (pluginInput as object))
+		(pluginInput &&
+			typeof pluginInput === "object" &&
+			"then" in (pluginInput as object))
 	) {
 		const mod = await (pluginInput as Promise<unknown>);
 		return Object.values(mod as object).find(


### PR DESCRIPTION
## Summary

- **Déduplication majeure** : 6 fonctions `scan*` quasi-identiques (~300 lignes) remplacées par une seule fonction générique `scanDir<T>` dans `common.ts`
- **Plugin resolution** : la logique de résolution de plugin (Promise vs objet) était dupliquée dans `index.ts` et `config-type-generator.ts` → extraite dans `utils/plugin.ts`
- **`handleReload`** : le `if/else` à 6 branches (toutes identiques) remplacé par un flag `unloadBeforeReload` sur `HandlerConfig`
- **`build.ts`** : les 6 boucles `processFiles` identiques remplacées par une seule fonction helper

## Bugs fixes

- **Bug `--path`** : l'option `-p/--path` dans la commande `dev` était déclarée sans `<path>`, ce qui faisait que la valeur passée n'était jamais capturée
- **Performance chokidar** : suppression de `usePolling: true` + `interval: 300ms` — inutile sur Linux natif (inotify), causait un délai de 300ms sur chaque changement de fichier
- **TDZ au démarrage** : `index.ts` importait `djs.config.ts` pour les CLI plugins et avalait l'erreur silencieusement si `TOKEN` n'était pas défini. Bun cachait le module en état d'échec, causant une erreur TDZ incompréhensible quand `runBot` réimportait le même fichier. Fix : cache-busting `?t=Date.now()` sur l'import dans `runBot` + message d'erreur clair

## Test plan

- [x] `bun run build` passe sans erreurs (10/10 tasks)
- [x] `TOKEN=xxx bun dev` dans `app/` démarre le bot correctement
- [x] Sans `TOKEN`, l'erreur affichée est `Failed to load djs.config.ts: TOKEN environment variable is required` (lisible)
- [x] Le hot reload fonctionne : modifier un fichier de commande rechargement sans redémarrage
- [x] `djs-core build` génère toujours un bundle valide

🤖 Generated with [Claude Code](https://claude.com/claude-code)