### PR TITLE
fix(runtime): propagate default_member_permissions for nested commands

### DIFF
--- a/.changeset/fix-nested-command-permissions.md
+++ b/.changeset/fix-nested-command-permissions.md
@@ -1,0 +1,7 @@
+---
+"@djs-core/runtime": patch
+---
+
+Fix `default_member_permissions` not being applied when commands are nested under subcommand groups (e.g. `admin.logs.export`). Permissions from leaf commands are now merged onto the root slash command during sync.
+
+Add a console warning when subcommands under the same root command define different `default_member_permissions`, since Discord only supports one permission set per root command.

--- a/app/src/interactions/commands/admin/logs/export.ts
+++ b/app/src/interactions/commands/admin/logs/export.ts
@@ -1,8 +1,8 @@
 import { Command } from "@djs-core/runtime";
 import { PermissionFlagsBits } from "discord.js";
 export default new Command()
-  .setDescription("Ping the bot")
-  .setDefaultMemberPermissions(PermissionFlagsBits.Administrator)
+	.setDescription("Ping the bot")
+	.setDefaultMemberPermissions(PermissionFlagsBits.Administrator)
 	.addStringOption((option) =>
 		option
 			.setName("type")

--- a/app/src/interactions/commands/admin/logs/export.ts
+++ b/app/src/interactions/commands/admin/logs/export.ts
@@ -1,6 +1,8 @@
 import { Command } from "@djs-core/runtime";
+import { PermissionFlagsBits } from "discord.js";
 export default new Command()
-	.setDescription("Ping the bot")
+  .setDescription("Ping the bot")
+  .setDefaultMemberPermissions(PermissionFlagsBits.Administrator)
 	.addStringOption((option) =>
 		option
 			.setName("type")

--- a/app/src/interactions/commands/admin/moderation/kick.ts
+++ b/app/src/interactions/commands/admin/moderation/kick.ts
@@ -1,6 +1,8 @@
 import { Command } from "@djs-core/runtime";
+import { PermissionFlagsBits } from "discord.js";
 export default new Command()
-	.setDescription("Kick a user")
+  .setDescription("Kick a user")
+	.setDefaultMemberPermissions(PermissionFlagsBits.KickMembers)
 	.run(async (interaction) => {
 		await interaction.reply("Pong!");
 	});

--- a/app/src/interactions/commands/admin/moderation/kick.ts
+++ b/app/src/interactions/commands/admin/moderation/kick.ts
@@ -1,7 +1,7 @@
 import { Command } from "@djs-core/runtime";
 import { PermissionFlagsBits } from "discord.js";
 export default new Command()
-  .setDescription("Kick a user")
+	.setDescription("Kick a user")
 	.setDefaultMemberPermissions(PermissionFlagsBits.KickMembers)
 	.run(async (interaction) => {
 		await interaction.reply("Pong!");

--- a/packages/runtime/handler/ApplicationCommandHandler.ts
+++ b/packages/runtime/handler/ApplicationCommandHandler.ts
@@ -9,6 +9,7 @@ import type { DjsClient } from "../DjsClient";
 import type Command from "../interaction/Command";
 import type ContextMenu from "../interaction/ContextMenu";
 import {
+	applyDefaultMemberPermissions,
 	buildCommandStructure,
 	routesToEntries,
 } from "../utils/compile-command";
@@ -167,6 +168,7 @@ export default class ApplicationCommandHandler {
 		}
 
 		this.applyDefaultContext(builder, entries);
+		applyDefaultMemberPermissions(builder, entries);
 		const json = builder.toJSON();
 		if (json.contexts && json.contexts.length === 0) delete json.contexts;
 		return json;

--- a/packages/runtime/handler/CommandHandler.ts
+++ b/packages/runtime/handler/CommandHandler.ts
@@ -7,6 +7,7 @@ import type {
 } from "discord.js";
 import type Command from "../interaction/Command";
 import {
+	applyDefaultMemberPermissions,
 	buildCommandStructure,
 	routesToEntries,
 } from "../utils/compile-command";
@@ -217,9 +218,8 @@ export default class CommandHandler {
 		) {
 			// biome-ignore lint/style/noNonNullAssertion: guarded by subcommands.has("__root__") above
 			const cmd = subcommands.get("__root__")!;
-			const cmdWithDesc = cmd as SlashCommandBuilder & { description?: string };
-			builder.setDescription(cmdWithDesc.description ?? "No description");
-			return builder.toJSON();
+			if (!cmd.name) cmd.setName(root);
+			return cmd.toJSON();
 		}
 
 		for (const [name, cmd] of subcommands) {
@@ -252,6 +252,7 @@ export default class CommandHandler {
 			});
 		}
 
+		applyDefaultMemberPermissions(builder, entries);
 		return builder.toJSON();
 	}
 

--- a/packages/runtime/test/compile-command.test.ts
+++ b/packages/runtime/test/compile-command.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, mock, test } from "bun:test";
+import { PermissionFlagsBits } from "discord.js";
+import Command from "../interaction/Command";
+import {
+	applyDefaultMemberPermissions,
+	buildCommandStructure,
+	routesToEntries,
+} from "../utils/compile-command";
+
+describe("applyDefaultMemberPermissions", () => {
+	test("merges leaf permissions onto root builder for nested routes", () => {
+		const exportCmd = new Command()
+			.setName("export")
+			.setDescription("export")
+			.setDefaultMemberPermissions(PermissionFlagsBits.Administrator);
+
+		const kickCmd = new Command().setName("kick").setDescription("kick");
+
+		const routes = [
+			{ route: "admin.logs.export", command: exportCmd },
+			{ route: "admin.moderation.kick", command: kickCmd },
+		];
+
+		const entries = routesToEntries(routes, "admin");
+		const { groups, builder } = buildCommandStructure(
+			"admin",
+			entries,
+			() => "admin cmd",
+		);
+
+		for (const [groupName, subs] of groups) {
+			builder.addSubcommandGroup((g) => {
+				g.setName(groupName).setDescription("No description");
+				for (const [subName, cmd] of subs) {
+					g.addSubcommand((sc) =>
+						sc.setName(subName).setDescription(cmd.description ?? "x"),
+					);
+				}
+				return g;
+			});
+		}
+
+		applyDefaultMemberPermissions(builder, entries);
+
+		expect(Number(builder.toJSON().default_member_permissions)).toBe(
+			Number(PermissionFlagsBits.Administrator),
+		);
+	});
+
+	test("warns when subcommands have different default_member_permissions", () => {
+		const warnSpy = mock(() => {});
+		const originalWarn = console.warn;
+		console.warn = warnSpy;
+
+		try {
+			const exportCmd = new Command()
+				.setName("export")
+				.setDescription("export")
+				.setDefaultMemberPermissions(PermissionFlagsBits.Administrator);
+
+			const kickCmd = new Command()
+				.setName("kick")
+				.setDescription("kick")
+				.setDefaultMemberPermissions(PermissionFlagsBits.KickMembers);
+
+			const routes = [
+				{ route: "admin.logs.export", command: exportCmd },
+				{ route: "admin.moderation.kick", command: kickCmd },
+			];
+
+			const entries = routesToEntries(routes, "admin");
+			const { builder } = buildCommandStructure(
+				"admin",
+				entries,
+				() => "admin cmd",
+			);
+
+			applyDefaultMemberPermissions(builder, entries);
+
+			expect(warnSpy).toHaveBeenCalledTimes(1);
+			expect(String(warnSpy.mock.calls[0]?.[0])).toContain(
+				"subcommands with different default_member_permissions",
+			);
+
+			applyDefaultMemberPermissions(builder, entries);
+			expect(warnSpy).toHaveBeenCalledTimes(2);
+		} finally {
+			console.warn = originalWarn;
+		}
+	});
+});

--- a/packages/runtime/utils/compile-command.ts
+++ b/packages/runtime/utils/compile-command.ts
@@ -70,3 +70,74 @@ export function routesToEntries(
 		})
 		.map((r) => ({ parts: splitRoute(r.route), cmd: r.command }));
 }
+
+type MemberPermissions = bigint | number | string | null | undefined;
+
+function permissionKey(perms: MemberPermissions): string {
+	return perms == null ? "__none__" : BigInt(perms).toString();
+}
+
+function formatPermissionLabel(key: string): string {
+	return key === "__none__" ? "none (everyone)" : key;
+}
+
+function warnPermissionMismatch(
+	root: string,
+	routes: Array<{ parts: string[]; cmd: Command }>,
+): void {
+	if (routes.length <= 1) {
+		return;
+	}
+
+	const byPermission = new Map<string, string[]>();
+	for (const r of routes) {
+		const key = permissionKey(r.cmd.default_member_permissions);
+		const route = r.parts.join(".");
+		const routesForKey = byPermission.get(key);
+		if (routesForKey) routesForKey.push(route);
+		else byPermission.set(key, [route]);
+	}
+
+	if (byPermission.size <= 1) {
+		return;
+	}
+
+	const details = [...byPermission.entries()]
+		.map(
+			([key, routeLabels]) =>
+				`  - ${routeLabels.join(", ")}: ${formatPermissionLabel(key)}`,
+		)
+		.join("\n");
+
+	console.warn(
+		`⚠️  Command '/${root}' has subcommands with different default_member_permissions. ` +
+			"Discord only supports one permission set on the root command; merged permissions were applied.\n" +
+			details,
+	);
+}
+
+/**
+ * Discord only supports default_member_permissions on the root slash command.
+ * Merge permissions from all leaf commands (bitwise OR) onto the root builder.
+ */
+export function applyDefaultMemberPermissions(
+	target: SlashCommandBuilder,
+	routes: RouteEntry[],
+): void {
+	const root = routes[0]?.parts[0];
+	if (root) {
+		warnPermissionMismatch(root, routes);
+	}
+
+	let merged: bigint | null = null;
+
+	for (const r of routes) {
+		const perms = r.cmd.default_member_permissions;
+		if (perms == null) continue;
+		merged = merged == null ? BigInt(perms) : merged | BigInt(perms);
+	}
+
+	if (merged != null) {
+		target.setDefaultMemberPermissions(merged);
+	}
+}


### PR DESCRIPTION
## Summary
- Fix `default_member_permissions` being dropped when compiling nested slash commands (e.g. `admin.logs.export`) during sync/hot reload
- Merge leaf permissions onto the root command and warn when subcommands under the same root define different permission sets
- Add unit tests and a patch changeset for `@djs-core/runtime`

## Test plan
- [x] `bun test packages/runtime/test/compile-command.test.ts`
- [x] `bun run build`
- [ ] Restart bot / reload a nested admin route and confirm the permission mismatch warning appears on each sync
- [ ] Verify `/admin logs export` is hidden for non-admin members after command sync